### PR TITLE
Sync upstream v1.79 + fix paste crash (#204), Deepgram auto-detect (#742), idle ASR failure (#614)

### DIFF
--- a/native-macos/Zerm/CursorPaster.swift
+++ b/native-macos/Zerm/CursorPaster.swift
@@ -86,9 +86,10 @@ class CursorPaster {
         }
     }
 
+    @MainActor
     private static func postPasteCommand() async -> PasteResult {
         if UserDefaults.standard.bool(forKey: "useAppleScriptPaste") {
-            return await pasteUsingAppleScript() ? .commandPosted : .commandNotPosted
+            return pasteUsingAppleScript() ? .commandPosted : .commandNotPosted
         } else {
             return await pasteFromClipboard()
         }
@@ -150,38 +151,38 @@ class CursorPaster {
     private static let pasteScriptKeystroke = makeScript("tell application \"System Events\" to keystroke \"v\" using command down")
     private static let pasteScriptKeyCode   = makeScript("tell application \"System Events\" to key code 9 using command down")
 
+    @MainActor
     private static var layoutSwitchesToQWERTYOnCommand: Bool {
         let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
         guard let nameRef = TISGetInputSourceProperty(source, kTISPropertyLocalizedName) else { return false }
         return (Unmanaged<CFString>.fromOpaque(nameRef).takeUnretainedValue() as String).hasSuffix("⌘")
     }
 
-    // Dispatches AppleScript execution to a background thread.
-    // NSAppleScript.executeAndReturnError is a blocking call; on macOS 26 it has an
-    // internal queue assertion that fires if called from the main queue (EXC_BREAKPOINT /
-    // dispatch_assert_queue_fail). Running it off-main satisfies the assertion and
-    // prevents the hard crash reported in VoiceInk issue #737.
-    private static func pasteUsingAppleScript() async -> Bool {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                guard let script = layoutSwitchesToQWERTYOnCommand ? pasteScriptKeyCode : pasteScriptKeystroke else {
-                    logger.error("AppleScript paste script is unavailable")
-                    continuation.resume(returning: false)
-                    return
-                }
-                var error: NSDictionary?
-                script.executeAndReturnError(&error)
-                if let error {
-                    logger.error("AppleScript paste failed: \(String(describing: error), privacy: .public)")
-                }
-                continuation.resume(returning: error == nil)
-            }
+    // Must run on the main thread. On macOS 26 both the Text Input Source APIs
+    // (TISCopyCurrentKeyboardInputSource / TISGetInputSourceProperty, via
+    // layoutSwitchesToQWERTYOnCommand) and NSAppleScript execution assert they are
+    // called from the main queue — calling them off-main triggers
+    // dispatch_assert_queue_fail (EXC_BREAKPOINT / SIGTRAP). This matches the fix in
+    // VoiceInk v1.79 for issue #737, and fixes the regression crash reported in
+    // Zerm #204 (an earlier off-main dispatch crashed inside the TIS layout read).
+    @MainActor
+    private static func pasteUsingAppleScript() -> Bool {
+        guard let script = layoutSwitchesToQWERTYOnCommand ? pasteScriptKeyCode : pasteScriptKeystroke else {
+            logger.error("AppleScript paste script is unavailable")
+            return false
         }
+        var error: NSDictionary?
+        script.executeAndReturnError(&error)
+        if let error {
+            logger.error("AppleScript paste failed: \(String(describing: error), privacy: .public)")
+        }
+        return error == nil
     }
 
     // MARK: - CGEvent paste
 
     // Posts Cmd+V via CGEvent without modifying the active input source.
+    @MainActor
     private static func pasteFromClipboard() async -> PasteResult {
         guard AXIsProcessTrusted() else {
             logger.error("Accessibility permission is required to paste with simulated key events")

--- a/native-macos/Zerm/Transcription/Cloud/DeepgramProvider.swift
+++ b/native-macos/Zerm/Transcription/Cloud/DeepgramProvider.swift
@@ -44,8 +44,16 @@ struct DeepgramProvider: CloudProvider {
             audioData: audioData,
             apiKey: apiKey,
             model: model,
-            language: language
+            language: Self.resolvedLanguage(language, model: model)
         )
+    }
+
+    /// Deepgram performs no language auto-detection when the `language` param is omitted — it
+    /// silently transcribes as English. For the multilingual Nova-3 model, "multi" enables
+    /// Deepgram's built-in multilingual code-switching, so "Auto detect" actually works. (VoiceInk #742)
+    static func resolvedLanguage(_ language: String?, model: String) -> String? {
+        if let language, !language.isEmpty { return language }
+        return model == "nova-3" ? "multi" : language
     }
 
     func makeStreamingProvider(modelContext: ModelContext) -> (any StreamingTranscriptionProvider)? {

--- a/native-macos/Zerm/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/native-macos/Zerm/Transcription/FluidAudio/FluidAudioTranscriptionService.swift
@@ -118,10 +118,33 @@ class FluidAudioTranscriptionService: TranscriptionService {
             speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
         }
 
-        var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
-        let result = try await asrManager.transcribe(speechAudio, decoderState: &decoderState)
+        do {
+            var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
+            let result = try await asrManager.transcribe(speechAudio, decoderState: &decoderState)
+            return TextNormalizer.shared.normalizeSentence(result.text)
+        } catch {
+            // CoreML model handles can go stale after the app sits idle and memory is paged
+            // out, surfacing as "Unable to compute asynchronous prediction using ML Program".
+            // The manager still reports as loaded, so a plain retry reuses the broken handles —
+            // reload the models from disk and re-create the manager once, then retry. (VoiceInk #614)
+            logger.notice("ASR prediction failed; reloading models and retrying once: \(error.localizedDescription, privacy: .public)")
+            await reloadModels(for: targetVersion)
+            guard let reloadedManager = self.asrManager else { throw error }
+            var retryDecoderState = TdtDecoderState.make(decoderLayers: await reloadedManager.decoderLayerCount)
+            let result = try await reloadedManager.transcribe(speechAudio, decoderState: &retryDecoderState)
+            return TextNormalizer.shared.normalizeSentence(result.text)
+        }
+    }
 
-        return TextNormalizer.shared.normalizeSentence(result.text)
+    /// Forces a fresh model reload from disk, discarding cached (possibly stale) CoreML handles. (VoiceInk #614)
+    private func reloadModels(for version: AsrModelVersion) async {
+        await asrManager?.cleanup()
+        asrManager = nil
+        vadManager = nil
+        activeVersion = nil
+        cachedModels = nil
+        loadingTask = nil
+        try? await ensureModelsLoaded(for: version)
     }
 
     private func readAudioSamples(from url: URL) throws -> [Float] {

--- a/native-macos/Zerm/Transcription/Streaming/DeepgramStreamingProvider.swift
+++ b/native-macos/Zerm/Transcription/Streaming/DeepgramStreamingProvider.swift
@@ -36,7 +36,10 @@ final class DeepgramStreamingProvider: StreamingTranscriptionProvider {
         startEventForwarding()
 
         do {
-            try await client.connect(apiKey: apiKey, model: model.name, language: language, customVocabulary: vocabulary)
+            // Map "Auto detect" to Deepgram's multilingual "multi" for Nova-3; otherwise
+            // an omitted language silently defaults to English. (VoiceInk #742)
+            let resolvedLanguage = DeepgramProvider.resolvedLanguage(language, model: model.name)
+            try await client.connect(apiKey: apiKey, model: model.name, language: resolvedLanguage, customVocabulary: vocabulary)
         } catch {
             // Clean up forwarding task on connection failure
             forwardingTask?.cancel()


### PR DESCRIPTION
## Summary
Syncs the relevant fix from upstream VoiceInk **v1.79** and fixes three issues. Build verified (`xcodebuild` Debug, BUILD SUCCEEDED).

### Fixes
- **macOS 26 paste crash (Zerm #204 / VoiceInk #737).** The AppleScript paste path ran on a background queue, but the TIS input-source APIs (`layoutSwitchesToQWERTYOnCommand`) assert they must run on the main queue on macOS 26 → `dispatch_assert_queue_fail` / SIGTRAP. This is a real user crash on 26.5. Fixed by running the path on `@MainActor`, matching upstream's v1.79 fix. The earlier off-main dispatch was backwards.
- **Deepgram auto-detect (VoiceInk #742).** "Auto detect" sent no language param, so Deepgram silently defaulted to English. Maps auto → `multi` for the multilingual Nova-3 model in both batch and streaming paths.
- **Idle ASR failure (VoiceInk #614).** First FluidAudio inference after idle could fail with "Unable to compute asynchronous prediction" (stale CoreML handles after memory paging). Adds a one-shot reload-from-disk + retry.

### Upstream sync note
v1.79's other changes don't apply: the Fn synthetic-arrow fix targets an architecture we don't share (we use exact keyCode `0x3F` + a companion-key monitor), and the paste-method refactor is structural only.

### Files
`CursorPaster.swift`, `DeepgramProvider.swift`, `DeepgramStreamingProvider.swift`, `FluidAudioTranscriptionService.swift`