### PR TITLE
Fix Voxtral streaming 400 (#36) and Whisper hallucination (#150)

### DIFF
--- a/native-macos/Zerm/Transcription/Cloud/MistralProvider.swift
+++ b/native-macos/Zerm/Transcription/Cloud/MistralProvider.swift
@@ -17,7 +17,9 @@ struct MistralProvider: CloudProvider {
             speed: 0.99,
             accuracy: 0.98,
             isMultilingual: true,
-            supportsStreaming: true,
+            // Streaming disabled: the realtime model id (voxtral-mini-transcribe-realtime-2602)
+            // was retired by Mistral and now 400s on every connect (#36). Use batch transcription.
+            supportsStreaming: false,
             supportedLanguages: LanguageDictionary.forProvider(isMultilingual: true, provider: .mistral)
         )
     ]}

--- a/native-macos/Zerm/Transcription/Whisper/LibWhisper.swift
+++ b/native-macos/Zerm/Transcription/Whisper/LibWhisper.swift
@@ -65,7 +65,10 @@ actor WhisperContext {
         params.offset_ms = 0
         params.no_context = true
         params.single_segment = false
-        params.temperature = 0.2
+        // Greedy/deterministic first pass to reduce hallucinated repetition/gibberish (#150).
+        // whisper.cpp still falls back to higher temperatures (default temperature_inc) when the
+        // entropy/logprob thresholds are exceeded, so quality on hard audio is preserved.
+        params.temperature = 0.0
 
         whisper_reset_timings(context)
         


### PR DESCRIPTION
## Summary
Two small, self-contained transcription correctness fixes surfaced during issue triage. Build verified (`xcodebuild` Debug, **BUILD SUCCEEDED**).

### Fixes
- **Voxtral Realtime 400 (#36).** The streaming path hardcoded the model id `voxtral-mini-transcribe-realtime-2602`, which Mistral retired — `StreamingKeysMigration.swift` already maps it away. Every streaming connect 400s, wasting a failed WebSocket attempt before falling back to batch (and logging an error each recording). Set `supportsStreaming: false` on the Voxtral model so it uses batch transcription directly. (`MistralProvider.swift`)
- **Whisper hallucination/repetition (#150).** Local Whisper decoding used a 0.2 starting temperature (arbitrary, present since the initial native commit), which raises first-pass hallucinated repetition/gibberish. Switched to `0.0` (greedy). whisper.cpp's default temperature fallback still engages on hard audio via the entropy/logprob thresholds, so quality on difficult input is preserved. (`LibWhisper.swift`)

### Test
- `xcodebuild -scheme Zerm -configuration Debug build` → BUILD SUCCEEDED.
- #36 is a clear correctness fix. #150 is a low-risk decode-parameter change aligned with whisper.cpp's canonical defaults; ideally spot-check transcription on a couple of recordings before tagging a release.