### PR TITLE
On-device Kokoro TTS (#210): sherpa-onnx + auto-downloaded model

### DIFF
--- a/native-macos/Makefile
+++ b/native-macos/Makefile
@@ -2,9 +2,13 @@
 DEPS_DIR := $(HOME)/Zerm-Dependencies
 WHISPER_CPP_DIR := $(DEPS_DIR)/whisper.cpp
 FRAMEWORK_PATH := $(WHISPER_CPP_DIR)/build-apple/whisper.xcframework
+SHERPA_DIR := $(DEPS_DIR)/sherpa-onnx
+SHERPA_BUILD := $(SHERPA_DIR)/build-swift-macos
+SHERPA_XCFRAMEWORK := $(SHERPA_BUILD)/sherpa-onnx.xcframework
+ONNX_XCFRAMEWORK := $(SHERPA_BUILD)/onnxruntime.xcframework
 LOCAL_DERIVED_DATA := $(CURDIR)/.local-build
 
-.PHONY: all clean whisper setup build local check healthcheck help dev run install reset-permissions
+.PHONY: all clean whisper sherpa setup build local check healthcheck help dev run install reset-permissions
 
 # Default target
 all: check build
@@ -37,9 +41,29 @@ whisper:
 		echo "whisper.xcframework already built in $(DEPS_DIR), skipping build"; \
 	fi
 
-setup: whisper
+# Build sherpa-onnx + onnxruntime xcframeworks for on-device Kokoro TTS (Read Aloud feature)
+sherpa:
+	@mkdir -p $(DEPS_DIR)
+	@if [ ! -d "$(SHERPA_XCFRAMEWORK)" ]; then \
+		echo "Building sherpa-onnx.xcframework in $(DEPS_DIR)..."; \
+		if [ ! -d "$(SHERPA_DIR)" ]; then \
+			git clone --depth 1 https://github.com/k2-fsa/sherpa-onnx.git $(SHERPA_DIR); \
+		fi; \
+		cd $(SHERPA_DIR) && ./build-swift-macos.sh; \
+	else \
+		echo "sherpa-onnx.xcframework already built, skipping"; \
+	fi
+	@if [ ! -d "$(ONNX_XCFRAMEWORK)" ]; then \
+		echo "Packaging onnxruntime.xcframework..."; \
+		cd $(SHERPA_BUILD) && xcodebuild -create-xcframework -library install/lib/libonnxruntime.a -output onnxruntime.xcframework; \
+	else \
+		echo "onnxruntime.xcframework already built, skipping"; \
+	fi
+
+setup: whisper sherpa
 	@echo "Whisper framework is ready at $(FRAMEWORK_PATH)"
-	@echo "Please ensure your Xcode project references the framework from this new location."
+	@echo "sherpa-onnx framework is ready at $(SHERPA_XCFRAMEWORK)"
+	@echo "Please ensure your Xcode project references the frameworks from these locations."
 
 build: setup
 	xcodebuild -project Zerm.xcodeproj -scheme Zerm -configuration Debug CODE_SIGN_IDENTITY="" build

--- a/native-macos/Zerm.xcodeproj/project.pbxproj
+++ b/native-macos/Zerm.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		E1F1037B2EF85FC700A4FF94 /* SelectedTextKit in Frameworks */ = {isa = PBXBuildFile; productRef = E1F1037A2EF85FC700A4FF94 /* SelectedTextKit */; };
 		E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; };
 		E1F350122F1D10D600790A2C /* whisper.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D7A1C0DE0000000000000001 /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A1C0DE0000000000000002 /* sherpa-onnx.xcframework */; };
+		D7A1C0DE0000000000000003 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A1C0DE0000000000000004 /* onnxruntime.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +62,8 @@
 		E11473CD2CBE0F0B00318EE4 /* ZermUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZermUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E161D4A02F41ECB90086F83D /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		E1A0BD052EB1E7B800266859 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "$(HOME)/Zerm-Dependencies/whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
+		D7A1C0DE0000000000000002 /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "$(HOME)/Zerm-Dependencies/sherpa-onnx/build-swift-macos/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
+		D7A1C0DE0000000000000004 /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "onnxruntime.xcframework"; path = "$(HOME)/Zerm-Dependencies/sherpa-onnx/build-swift-macos/onnxruntime.xcframework"; sourceTree = "<group>"; };
 		E1B2DCAA2E3DE70A008DFD68 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 		E1CE28772E4336150082B758 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -89,6 +93,8 @@
 			files = (
 				E1342C1F2EB4844800CED8A2 /* Atomics in Frameworks */,
 				E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */,
+				D7A1C0DE0000000000000001 /* sherpa-onnx.xcframework in Frameworks */,
+				D7A1C0DE0000000000000003 /* onnxruntime.xcframework in Frameworks */,
 				E1ECEC162E44591300DFFBA8 /* Zip in Frameworks */,
 				E1ADD45A2CC5352A00303ECB /* LaunchAtLogin in Frameworks */,
 				E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */,
@@ -470,6 +476,13 @@
 		E11473D82CBE0F0B00318EE4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SWIFT_OBJC_BRIDGING_HEADER = "Zerm/Zerm-Bridging-Header.h";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-framework",
+					Accelerate,
+				);
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -504,6 +517,13 @@
 		E11473D92CBE0F0B00318EE4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SWIFT_OBJC_BRIDGING_HEADER = "Zerm/Zerm-Bridging-Header.h";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-framework",
+					Accelerate,
+				);
 				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/native-macos/Zerm/TextToSpeech/Kokoro/KokoroEngine.swift
+++ b/native-macos/Zerm/TextToSpeech/Kokoro/KokoroEngine.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Thread-safe wrapper around sherpa-onnx's offline Kokoro TTS. Mirrors how `WhisperContext`
+/// isolates the (non-thread-safe) whisper.cpp C API in an actor.
+///
+/// The model (~330 MB) is loaded lazily on the actor's executor the first time `generate`
+/// is called, so the heavy load never blocks the main thread.
+actor KokoroEngine {
+    private let modelPath: String
+    private let voicesPath: String
+    private let tokensPath: String
+    private let dataDir: String
+    private var tts: SherpaOnnxOfflineTtsWrapper?
+
+    init(model: String, voices: String, tokens: String, dataDir: String) {
+        self.modelPath = model
+        self.voicesPath = voices
+        self.tokensPath = tokens
+        self.dataDir = dataDir
+    }
+
+    private func ensureLoaded() throws {
+        guard tts == nil else { return }
+        let kokoro = sherpaOnnxOfflineTtsKokoroModelConfig(
+            model: modelPath, voices: voicesPath, tokens: tokensPath, dataDir: dataDir
+        )
+        let modelConfig = sherpaOnnxOfflineTtsModelConfig(kokoro: kokoro, numThreads: 2, provider: "cpu")
+        var config = sherpaOnnxOfflineTtsConfig(model: modelConfig)
+        let wrapper = SherpaOnnxOfflineTtsWrapper(config: &config)
+        guard wrapper.tts != nil else {
+            throw TTSError.notAvailable("Failed to initialize the on-device Kokoro engine.")
+        }
+        tts = wrapper
+    }
+
+    func generate(text: String, sid: Int, speed: Float) throws -> (samples: [Float], sampleRate: Int) {
+        try ensureLoaded()
+        guard let tts else { throw TTSError.notAvailable("Kokoro engine unavailable.") }
+        let audio = tts.generate(text: text, sid: sid, speed: speed)
+        return (audio.samples, Int(audio.sampleRate))
+    }
+}

--- a/native-macos/Zerm/TextToSpeech/Kokoro/KokoroModelManager.swift
+++ b/native-macos/Zerm/TextToSpeech/Kokoro/KokoroModelManager.swift
@@ -1,0 +1,193 @@
+import Foundation
+import os
+
+/// Describes the downloadable sherpa-onnx Kokoro model package.
+struct KokoroModelPackage {
+    let name: String          // archive base name, also the extracted folder name
+    let displayName: String
+    let approxSize: String
+    let downloadURL: URL
+
+    /// Files that must exist after extraction for the package to be considered installed.
+    var requiredFiles: [String] { ["model.onnx", "voices.bin", "tokens.txt"] }
+    /// espeak-ng phonemizer data directory (required by Kokoro).
+    var dataDirName: String { "espeak-ng-data" }
+}
+
+/// Downloads, stores, and serves the on-device Kokoro TTS model — the synthesis
+/// counterpart of `WhisperModelManager`. Same UX: first use auto-downloads with a
+/// progress bar, then everything runs offline.
+@MainActor
+final class KokoroModelManager: ObservableObject {
+    static let shared = KokoroModelManager()
+
+    /// English Kokoro v0.19 (11 speakers) — Apache-2.0 weights, hosted on the sherpa-onnx release.
+    static let package = KokoroModelPackage(
+        name: "kokoro-en-v0_19",
+        displayName: "Kokoro 82M (English, on-device)",
+        approxSize: "~330 MB",
+        downloadURL: URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/kokoro-en-v0_19.tar.bz2")!
+    )
+
+    @Published private(set) var isInstalled = false
+    @Published private(set) var isDownloading = false
+    /// 0.0–1.0 while downloading/extracting; nil when idle.
+    @Published private(set) var downloadProgress: Double?
+    @Published private(set) var statusText: String?
+
+    let modelsDirectory: URL
+    private let logger = Logger(subsystem: "com.arcusis.zerm", category: "KokoroModelManager")
+    private var engine: KokoroEngine?
+    private var downloadTask: URLSessionDownloadTask?
+    private var progressObservation: NSKeyValueObservation?
+
+    private init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.arcusis.zerm")
+        modelsDirectory = appSupport.appendingPathComponent("TTSModels")
+        try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        refreshInstalled()
+    }
+
+    // MARK: - Paths
+
+    private var packageDir: URL {
+        modelsDirectory.appendingPathComponent(Self.package.name)
+    }
+
+    /// Resolved config paths sherpa-onnx needs.
+    var modelConfig: (model: String, voices: String, tokens: String, dataDir: String) {
+        (
+            model: packageDir.appendingPathComponent("model.onnx").path,
+            voices: packageDir.appendingPathComponent("voices.bin").path,
+            tokens: packageDir.appendingPathComponent("tokens.txt").path,
+            dataDir: packageDir.appendingPathComponent(Self.package.dataDirName).path
+        )
+    }
+
+    func refreshInstalled() {
+        let fm = FileManager.default
+        let filesPresent = Self.package.requiredFiles.allSatisfy {
+            fm.fileExists(atPath: packageDir.appendingPathComponent($0).path)
+        }
+        let dataPresent = fm.fileExists(atPath: packageDir.appendingPathComponent(Self.package.dataDirName).path)
+        isInstalled = filesPresent && dataPresent
+    }
+
+    // MARK: - Download + extract
+
+    func download() async {
+        guard !isDownloading else { return }
+        isDownloading = true
+        downloadProgress = 0
+        statusText = "Downloading Kokoro model…"
+        defer { isDownloading = false; downloadProgress = nil }
+
+        do {
+            let archiveURL = try await downloadArchive(from: Self.package.downloadURL)
+            statusText = "Extracting…"
+            downloadProgress = nil
+            try extractTarBz2(at: archiveURL, into: modelsDirectory)
+            try? FileManager.default.removeItem(at: archiveURL)
+            refreshInstalled()
+            statusText = isInstalled ? nil : "Extraction incomplete"
+            if !isInstalled { logger.error("Kokoro extraction finished but required files are missing") }
+        } catch is CancellationError {
+            statusText = "Download cancelled"
+        } catch {
+            logger.error("Kokoro download failed: \(error.localizedDescription, privacy: .public)")
+            statusText = "Download failed: \(error.localizedDescription)"
+        }
+    }
+
+    func cancelDownload() {
+        downloadTask?.cancel()
+        downloadTask = nil
+    }
+
+    func delete() {
+        engine = nil
+        try? FileManager.default.removeItem(at: packageDir)
+        refreshInstalled()
+    }
+
+    /// Downloads to a temp file, reporting fractional progress via KVO (mirrors WhisperModelManager).
+    private func downloadArchive(from url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = URLSession.shared.downloadTask(with: url) { [weak self] tempURL, response, error in
+                self?.progressObservation?.invalidate()
+                self?.progressObservation = nil
+                if let error { continuation.resume(throwing: error); return }
+                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                    continuation.resume(throwing: TTSError.http((response as? HTTPURLResponse)?.statusCode ?? -1, "download failed"))
+                    return
+                }
+                guard let tempURL else { continuation.resume(throwing: TTSError.badResponse); return }
+                do {
+                    let dest = self?.modelsDirectory.appendingPathComponent("kokoro-download.tar.bz2")
+                        ?? URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("kokoro.tar.bz2")
+                    try? FileManager.default.removeItem(at: dest)
+                    try FileManager.default.moveItem(at: tempURL, to: dest)
+                    continuation.resume(returning: dest)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+            self.downloadTask = task
+            self.progressObservation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+                Task { @MainActor in self?.downloadProgress = progress.fractionCompleted }
+            }
+            task.resume()
+        }
+    }
+
+    /// Extracts a .tar.bz2 via bsdtar (`/usr/bin/tar`), which handles bzip2 natively on macOS.
+    private func extractTarBz2(at archiveURL: URL, into dest: URL) throws {
+        try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["-x", "-j", "-f", archiveURL.path, "-C", dest.path]
+        let errPipe = Pipe()
+        process.standardError = errPipe
+        process.standardOutput = Pipe()
+        try process.run()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()  // drain before wait
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw TTSError.notAvailable("Failed to extract model: \(String(data: errData, encoding: .utf8) ?? "tar error")")
+        }
+    }
+
+    // MARK: - Synthesis
+
+    /// Synthesizes `text` with the given speaker id (sid) and speed, returning 16-bit PCM.
+    /// Loads the engine on first use; runs inference off the main thread.
+    func synthesize(text: String, sid: Int, speed: Double) async throws -> TTSAudio {
+        guard isInstalled else {
+            throw TTSError.notAvailable("The on-device Kokoro model isn't downloaded yet. Download it in Read Aloud settings.")
+        }
+        let engine = ensureEngine()
+        let (samples, sampleRate) = try await engine.generate(text: text, sid: sid, speed: Float(speed))
+        guard !samples.isEmpty else { throw TTSError.emptyAudio }
+        return TTSAudio(pcm: Self.floatToInt16PCM(samples), sampleRate: Double(sampleRate), channels: 1)
+    }
+
+    private func ensureEngine() -> KokoroEngine {
+        if let engine { return engine }
+        let cfg = modelConfig
+        let engine = KokoroEngine(model: cfg.model, voices: cfg.voices, tokens: cfg.tokens, dataDir: cfg.dataDir)
+        self.engine = engine
+        return engine
+    }
+
+    /// Converts sherpa-onnx Float samples ([-1, 1]) to signed 16-bit little-endian PCM.
+    private static func floatToInt16PCM(_ samples: [Float]) -> Data {
+        var data = Data(capacity: samples.count * 2)
+        for s in samples {
+            let clamped = max(-1.0, min(1.0, s))
+            var v = Int16(clamped * 32767.0).littleEndian
+            withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
+        }
+        return data
+    }
+}

--- a/native-macos/Zerm/TextToSpeech/Kokoro/SherpaOnnx.swift
+++ b/native-macos/Zerm/TextToSpeech/Kokoro/SherpaOnnx.swift
@@ -1,0 +1,2268 @@
+/// swift-api-examples/SherpaOnnx.swift
+/// Copyright (c)  2023  Xiaomi Corporation
+
+import Foundation  // For NSString
+
+/// Convert a String from swift to a `const char*` so that we can pass it to
+/// the C language.
+///
+/// - Parameters:
+///   - s: The String to convert.
+/// - Returns: A pointer that can be passed to C as `const char*`
+
+func toCPointer(_ s: String) -> UnsafePointer<Int8>! {
+  let cs = (s as NSString).utf8String
+  return UnsafePointer<Int8>(cs)
+}
+
+/// Return an instance of SherpaOnnxOnlineTransducerModelConfig.
+///
+/// Please refer to
+/// https://k2-fsa.github.io/sherpa/onnx/pretrained_models/online-transducer/index.html
+/// to download the required `.onnx` files.
+///
+/// - Parameters:
+///   - encoder: Path to encoder.onnx
+///   - decoder: Path to decoder.onnx
+///   - joiner: Path to joiner.onnx
+///
+/// - Returns: Return an instance of SherpaOnnxOnlineTransducerModelConfig
+func sherpaOnnxOnlineTransducerModelConfig(
+  encoder: String = "",
+  decoder: String = "",
+  joiner: String = ""
+) -> SherpaOnnxOnlineTransducerModelConfig {
+  return SherpaOnnxOnlineTransducerModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    joiner: toCPointer(joiner)
+  )
+}
+
+/// Return an instance of SherpaOnnxOnlineParaformerModelConfig.
+///
+/// Please refer to
+/// https://k2-fsa.github.io/sherpa/onnx/pretrained_models/online-paraformer/index.html
+/// to download the required `.onnx` files.
+///
+/// - Parameters:
+///   - encoder: Path to encoder.onnx
+///   - decoder: Path to decoder.onnx
+///
+/// - Returns: Return an instance of SherpaOnnxOnlineParaformerModelConfig
+func sherpaOnnxOnlineParaformerModelConfig(
+  encoder: String = "",
+  decoder: String = ""
+) -> SherpaOnnxOnlineParaformerModelConfig {
+  return SherpaOnnxOnlineParaformerModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder)
+  )
+}
+
+func sherpaOnnxOnlineZipformer2CtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOnlineZipformer2CtcModelConfig {
+  return SherpaOnnxOnlineZipformer2CtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOnlineNemoCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOnlineNemoCtcModelConfig {
+  return SherpaOnnxOnlineNemoCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOnlineToneCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOnlineToneCtcModelConfig {
+  return SherpaOnnxOnlineToneCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+/// Return an instance of SherpaOnnxOnlineModelConfig.
+///
+/// Please refer to
+/// https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html
+/// to download the required `.onnx` files.
+///
+/// - Parameters:
+///   - tokens: Path to tokens.txt
+///   - numThreads:  Number of threads to use for neural network computation.
+///
+/// - Returns: Return an instance of SherpaOnnxOnlineTransducerModelConfig
+func sherpaOnnxOnlineModelConfig(
+  tokens: String,
+  transducer: SherpaOnnxOnlineTransducerModelConfig = sherpaOnnxOnlineTransducerModelConfig(),
+  paraformer: SherpaOnnxOnlineParaformerModelConfig = sherpaOnnxOnlineParaformerModelConfig(),
+  zipformer2Ctc: SherpaOnnxOnlineZipformer2CtcModelConfig =
+    sherpaOnnxOnlineZipformer2CtcModelConfig(),
+  numThreads: Int = 1,
+  provider: String = "cpu",
+  debug: Int = 0,
+  modelType: String = "",
+  modelingUnit: String = "cjkchar",
+  bpeVocab: String = "",
+  tokensBuf: String = "",
+  tokensBufSize: Int = 0,
+  nemoCtc: SherpaOnnxOnlineNemoCtcModelConfig = sherpaOnnxOnlineNemoCtcModelConfig(),
+  toneCtc: SherpaOnnxOnlineToneCtcModelConfig = sherpaOnnxOnlineToneCtcModelConfig()
+) -> SherpaOnnxOnlineModelConfig {
+  return SherpaOnnxOnlineModelConfig(
+    transducer: transducer,
+    paraformer: paraformer,
+    zipformer2_ctc: zipformer2Ctc,
+    tokens: toCPointer(tokens),
+    num_threads: Int32(numThreads),
+    provider: toCPointer(provider),
+    debug: Int32(debug),
+    model_type: toCPointer(modelType),
+    modeling_unit: toCPointer(modelingUnit),
+    bpe_vocab: toCPointer(bpeVocab),
+    tokens_buf: toCPointer(tokensBuf),
+    tokens_buf_size: Int32(tokensBufSize),
+    nemo_ctc: nemoCtc,
+    t_one_ctc: toneCtc
+  )
+}
+
+func sherpaOnnxFeatureConfig(
+  sampleRate: Int = 16000,
+  featureDim: Int = 80
+) -> SherpaOnnxFeatureConfig {
+  return SherpaOnnxFeatureConfig(
+    sample_rate: Int32(sampleRate),
+    feature_dim: Int32(featureDim))
+}
+
+func sherpaOnnxOnlineCtcFstDecoderConfig(
+  graph: String = "",
+  maxActive: Int = 3000
+) -> SherpaOnnxOnlineCtcFstDecoderConfig {
+  return SherpaOnnxOnlineCtcFstDecoderConfig(
+    graph: toCPointer(graph),
+    max_active: Int32(maxActive))
+}
+
+func sherpaOnnxHomophoneReplacerConfig(
+  dictDir: String = "",
+  lexicon: String = "",
+  ruleFsts: String = ""
+) -> SherpaOnnxHomophoneReplacerConfig {
+  return SherpaOnnxHomophoneReplacerConfig(
+    dict_dir: toCPointer(dictDir),
+    lexicon: toCPointer(lexicon),
+    rule_fsts: toCPointer(ruleFsts))
+}
+
+func sherpaOnnxOnlineRecognizerConfig(
+  featConfig: SherpaOnnxFeatureConfig,
+  modelConfig: SherpaOnnxOnlineModelConfig,
+  enableEndpoint: Bool = false,
+  rule1MinTrailingSilence: Float = 2.4,
+  rule2MinTrailingSilence: Float = 1.2,
+  rule3MinUtteranceLength: Float = 30,
+  decodingMethod: String = "greedy_search",
+  maxActivePaths: Int = 4,
+  hotwordsFile: String = "",
+  hotwordsScore: Float = 1.5,
+  ctcFstDecoderConfig: SherpaOnnxOnlineCtcFstDecoderConfig = sherpaOnnxOnlineCtcFstDecoderConfig(),
+  ruleFsts: String = "",
+  ruleFars: String = "",
+  blankPenalty: Float = 0.0,
+  hotwordsBuf: String = "",
+  hotwordsBufSize: Int = 0,
+  hr: SherpaOnnxHomophoneReplacerConfig = sherpaOnnxHomophoneReplacerConfig()
+) -> SherpaOnnxOnlineRecognizerConfig {
+  return SherpaOnnxOnlineRecognizerConfig(
+    feat_config: featConfig,
+    model_config: modelConfig,
+    decoding_method: toCPointer(decodingMethod),
+    max_active_paths: Int32(maxActivePaths),
+    enable_endpoint: enableEndpoint ? 1 : 0,
+    rule1_min_trailing_silence: rule1MinTrailingSilence,
+    rule2_min_trailing_silence: rule2MinTrailingSilence,
+    rule3_min_utterance_length: rule3MinUtteranceLength,
+    hotwords_file: toCPointer(hotwordsFile),
+    hotwords_score: hotwordsScore,
+    ctc_fst_decoder_config: ctcFstDecoderConfig,
+    rule_fsts: toCPointer(ruleFsts),
+    rule_fars: toCPointer(ruleFars),
+    blank_penalty: blankPenalty,
+    hotwords_buf: toCPointer(hotwordsBuf),
+    hotwords_buf_size: Int32(hotwordsBufSize),
+    hr: hr
+  )
+}
+
+/// Wrapper for recognition result.
+///
+/// Usage:
+///
+///  let result = recognizer.getResult()
+///  print("text: \(result.text)")
+///
+class SherpaOnnxOnlineRecongitionResult {
+  /// A pointer to the underlying counterpart in C
+  private let result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>
+
+  private lazy var _text: String = {
+    guard let cstr = result.pointee.text else { return "" }
+    return String(cString: cstr)
+  }()
+
+  private lazy var _tokens: [String] = {
+    guard let tokensPointer = result.pointee.tokens_arr else { return [] }
+    return (0..<count).compactMap { index in
+      guard let ptr = tokensPointer[index] else { return nil }
+      return String(cString: ptr)
+    }
+  }()
+
+  private lazy var _timestamps: [Float] = {
+    guard let timestampsPointer = result.pointee.timestamps else { return [] }
+    return (0..<count).map { index in timestampsPointer[index] }
+  }()
+
+  init(result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>) {
+    self.result = result
+  }
+
+  deinit {
+    SherpaOnnxDestroyOnlineRecognizerResult(result)
+  }
+
+  /// Return the actual recognition result.
+  /// For English models, it contains words separated by spaces.
+  /// For Chinese models, it contains Chinese words.
+  var text: String { _text }
+
+  var count: Int { Int(result.pointee.count) }
+
+  var tokens: [String] { _tokens }
+
+  var timestamps: [Float] { _timestamps }
+}
+
+class SherpaOnnxRecognizer {
+  /// A pointer to the underlying counterpart in C
+  private let recognizer: OpaquePointer
+  private var stream: OpaquePointer
+  private let lock = NSLock()  // for thread-safe stream replacement
+
+  /// Constructor taking a model config
+  init(
+    config: UnsafePointer<SherpaOnnxOnlineRecognizerConfig>
+  ) {
+    self.recognizer = SherpaOnnxCreateOnlineRecognizer(config)
+    self.stream = SherpaOnnxCreateOnlineStream(recognizer)
+  }
+
+  deinit {
+    SherpaOnnxDestroyOnlineStream(stream)
+    SherpaOnnxDestroyOnlineRecognizer(recognizer)
+  }
+
+  /// Decode wave samples.
+  ///
+  /// - Parameters:
+  ///   - samples: Audio samples normalized to the range [-1, 1]
+  ///   - sampleRate: Sample rate of the input audio samples. Must match
+  ///                 the one expected by the model.
+  func acceptWaveform(samples: [Float], sampleRate: Int = 16_000) {
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
+  }
+
+  func isReady() -> Bool {
+    return SherpaOnnxIsOnlineStreamReady(recognizer, stream) != 0
+  }
+
+  /// If there are enough number of feature frames, it invokes the neural
+  /// network computation and decoding. Otherwise, it is a no-op.
+  func decode() {
+    SherpaOnnxDecodeOnlineStream(recognizer, stream)
+  }
+
+  /// Get the decoding results so far
+  func getResult() -> SherpaOnnxOnlineRecongitionResult {
+    guard let result = SherpaOnnxGetOnlineStreamResult(recognizer, stream) else {
+      fatalError("SherpaOnnxGetOnlineStreamResult returned nil")
+    }
+    return SherpaOnnxOnlineRecongitionResult(result: result)
+  }
+
+  /// Reset the recognizer, which clears the neural network model state
+  /// and the state for decoding.
+  /// If hotwords is an empty string, it just recreates the decoding stream
+  /// If hotwords is not empty, it will create a new decoding stream with
+  /// the given hotWords appended to the default hotwords.
+  func reset(hotwords: String? = nil) {
+    guard let words = hotwords, !words.isEmpty else {
+      SherpaOnnxOnlineStreamReset(recognizer, stream)
+      return
+    }
+
+    words.withCString { cString in
+      guard let newStream = SherpaOnnxCreateOnlineStreamWithHotwords(recognizer, cString) else {
+        fatalError("SherpaOnnxCreateOnlineStreamWithHotwords returned nil")
+      }
+      lock.lock()
+      // lock while release and replace stream
+      SherpaOnnxDestroyOnlineStream(stream)
+      stream = newStream
+      lock.unlock()
+    }
+  }
+
+  /// Signal that no more audio samples would be available.
+  /// After this call, you cannot call acceptWaveform() any more.
+  func inputFinished() {
+    SherpaOnnxOnlineStreamInputFinished(stream)
+  }
+
+  /// Return true is an endpoint has been detected.
+  func isEndpoint() -> Bool {
+    return SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream) != 0
+  }
+}
+
+// For offline APIs
+
+func sherpaOnnxOfflineTransducerModelConfig(
+  encoder: String = "",
+  decoder: String = "",
+  joiner: String = ""
+) -> SherpaOnnxOfflineTransducerModelConfig {
+  return SherpaOnnxOfflineTransducerModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    joiner: toCPointer(joiner)
+  )
+}
+
+func sherpaOnnxOfflineParaformerModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineParaformerModelConfig {
+  return SherpaOnnxOfflineParaformerModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineZipformerCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineZipformerCtcModelConfig {
+  return SherpaOnnxOfflineZipformerCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineWenetCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineWenetCtcModelConfig {
+  return SherpaOnnxOfflineWenetCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineOmnilingualAsrCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineOmnilingualAsrCtcModelConfig {
+  return SherpaOnnxOfflineOmnilingualAsrCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineMedAsrCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineMedAsrCtcModelConfig {
+  return SherpaOnnxOfflineMedAsrCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineFireRedAsrCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineFireRedAsrCtcModelConfig {
+  return SherpaOnnxOfflineFireRedAsrCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineNemoEncDecCtcModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineNemoEncDecCtcModelConfig {
+  return SherpaOnnxOfflineNemoEncDecCtcModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineDolphinModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineDolphinModelConfig {
+  return SherpaOnnxOfflineDolphinModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineWhisperModelConfig(
+  encoder: String = "",
+  decoder: String = "",
+  language: String = "",
+  task: String = "transcribe",
+  tailPaddings: Int = -1,
+  enableTokenTimestamps: Bool = false,
+  enableSegmentTimestamps: Bool = false
+) -> SherpaOnnxOfflineWhisperModelConfig {
+  return SherpaOnnxOfflineWhisperModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    language: toCPointer(language),
+    task: toCPointer(task),
+    tail_paddings: Int32(tailPaddings),
+    enable_token_timestamps: enableTokenTimestamps ? 1 : 0,
+    enable_segment_timestamps: enableSegmentTimestamps ? 1 : 0
+  )
+}
+
+func sherpaOnnxOfflineCanaryModelConfig(
+  encoder: String = "",
+  decoder: String = "",
+  srcLang: String = "en",
+  tgtLang: String = "en",
+  usePnc: Bool = true
+) -> SherpaOnnxOfflineCanaryModelConfig {
+  return SherpaOnnxOfflineCanaryModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    src_lang: toCPointer(srcLang),
+    tgt_lang: toCPointer(tgtLang),
+    use_pnc: usePnc ? 1 : 0
+  )
+}
+
+func sherpaOnnxOfflineCohereTranscribeModelConfig(
+  encoder: String = "",
+  decoder: String = "",
+  language: String = "",
+  usePunct: Bool = true,
+  useInverseTextNormalization: Bool = true
+) -> SherpaOnnxOfflineCohereTranscribeModelConfig {
+  return SherpaOnnxOfflineCohereTranscribeModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    language: toCPointer(language),
+    use_punct: usePunct ? 1 : 0,
+    use_itn: useInverseTextNormalization ? 1 : 0
+  )
+}
+
+func sherpaOnnxOfflineFireRedAsrModelConfig(
+  encoder: String = "",
+  decoder: String = ""
+) -> SherpaOnnxOfflineFireRedAsrModelConfig {
+  return SherpaOnnxOfflineFireRedAsrModelConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder)
+  )
+}
+
+// there are two versions of Moonshine
+// For v1, you need four models: preprocessor, encoder, uncachedDecoder, cachedDecoder
+// For v2, you need two models: encoder, mergedDecoder
+func sherpaOnnxOfflineMoonshineModelConfig(
+  preprocessor: String = "",
+  encoder: String = "",
+  uncachedDecoder: String = "",
+  cachedDecoder: String = "",
+  mergedDecoder: String = ""
+) -> SherpaOnnxOfflineMoonshineModelConfig {
+  return SherpaOnnxOfflineMoonshineModelConfig(
+    preprocessor: toCPointer(preprocessor),
+    encoder: toCPointer(encoder),
+    uncached_decoder: toCPointer(uncachedDecoder),
+    cached_decoder: toCPointer(cachedDecoder),
+    merged_decoder: toCPointer(mergedDecoder)
+  )
+}
+
+func sherpaOnnxOfflineQwen3ASRModelConfig(
+  convFrontend: String = "",
+  encoder: String = "",
+  decoder: String = "",
+  tokenizer: String = "",
+  maxTotalLen: Int = 512,
+  maxNewTokens: Int = 128,
+  temperature: Float = 1e-6,
+  topP: Float = 0.8,
+  seed: Int = 42,
+  hotwords: String = ""
+) -> SherpaOnnxOfflineQwen3ASRModelConfig {
+  return SherpaOnnxOfflineQwen3ASRModelConfig(
+    conv_frontend: toCPointer(convFrontend),
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    tokenizer: toCPointer(tokenizer),
+    max_total_len: Int32(maxTotalLen),
+    max_new_tokens: Int32(maxNewTokens),
+    temperature: temperature,
+    top_p: topP,
+    seed: Int32(seed),
+    hotwords: toCPointer(hotwords)
+  )
+}
+
+func sherpaOnnxOfflineTdnnModelConfig(
+  model: String = ""
+) -> SherpaOnnxOfflineTdnnModelConfig {
+  return SherpaOnnxOfflineTdnnModelConfig(
+    model: toCPointer(model)
+  )
+}
+
+func sherpaOnnxOfflineSenseVoiceModelConfig(
+  model: String = "",
+  language: String = "",
+  useInverseTextNormalization: Bool = false
+) -> SherpaOnnxOfflineSenseVoiceModelConfig {
+  return SherpaOnnxOfflineSenseVoiceModelConfig(
+    model: toCPointer(model),
+    language: toCPointer(language),
+    use_itn: useInverseTextNormalization ? 1 : 0
+  )
+}
+
+func sherpaOnnxOfflineLMConfig(
+  model: String = "",
+  scale: Float = 1.0
+) -> SherpaOnnxOfflineLMConfig {
+  return SherpaOnnxOfflineLMConfig(
+    model: toCPointer(model),
+    scale: scale
+  )
+}
+
+func sherpaOnnxOfflineFunASRNanoModelConfig(
+  encoderAdaptor: String = "",
+  llm: String = "",
+  embedding: String = "",
+  tokenizer: String = "",
+  systemPrompt: String = "You are a helpful assistant.",
+  userPrompt: String = "语音转写：",
+  maxNewTokens: Int = 512,
+  temperature: Float = 1e-6,
+  topP: Float = 0.8,
+  seed: Int = 42,
+  language: String = "",
+  itn: Bool = true,
+  hotwords: String = ""
+) -> SherpaOnnxOfflineFunASRNanoModelConfig {
+  return SherpaOnnxOfflineFunASRNanoModelConfig(
+    encoder_adaptor: toCPointer(encoderAdaptor),
+    llm: toCPointer(llm),
+    embedding: toCPointer(embedding),
+    tokenizer: toCPointer(tokenizer),
+    system_prompt: toCPointer(systemPrompt),
+    user_prompt: toCPointer(userPrompt),
+    max_new_tokens: Int32(maxNewTokens),
+    temperature: temperature,
+    top_p: topP,
+    seed: Int32(seed),
+    language: toCPointer(language),
+    itn: itn ? 1 : 0,
+    hotwords: toCPointer(hotwords)
+  )
+}
+
+func sherpaOnnxOfflineModelConfig(
+  tokens: String,
+  transducer: SherpaOnnxOfflineTransducerModelConfig = sherpaOnnxOfflineTransducerModelConfig(),
+  paraformer: SherpaOnnxOfflineParaformerModelConfig = sherpaOnnxOfflineParaformerModelConfig(),
+  nemoCtc: SherpaOnnxOfflineNemoEncDecCtcModelConfig = sherpaOnnxOfflineNemoEncDecCtcModelConfig(),
+  whisper: SherpaOnnxOfflineWhisperModelConfig = sherpaOnnxOfflineWhisperModelConfig(),
+  tdnn: SherpaOnnxOfflineTdnnModelConfig = sherpaOnnxOfflineTdnnModelConfig(),
+  numThreads: Int = 1,
+  provider: String = "cpu",
+  debug: Int = 0,
+  modelType: String = "",
+  modelingUnit: String = "cjkchar",
+  bpeVocab: String = "",
+  teleSpeechCtc: String = "",
+  senseVoice: SherpaOnnxOfflineSenseVoiceModelConfig = sherpaOnnxOfflineSenseVoiceModelConfig(),
+  moonshine: SherpaOnnxOfflineMoonshineModelConfig = sherpaOnnxOfflineMoonshineModelConfig(),
+  fireRedAsr: SherpaOnnxOfflineFireRedAsrModelConfig = sherpaOnnxOfflineFireRedAsrModelConfig(),
+  dolphin: SherpaOnnxOfflineDolphinModelConfig = sherpaOnnxOfflineDolphinModelConfig(),
+  zipformerCtc: SherpaOnnxOfflineZipformerCtcModelConfig =
+    sherpaOnnxOfflineZipformerCtcModelConfig(),
+  canary: SherpaOnnxOfflineCanaryModelConfig = sherpaOnnxOfflineCanaryModelConfig(),
+  wenetCtc: SherpaOnnxOfflineWenetCtcModelConfig =
+    sherpaOnnxOfflineWenetCtcModelConfig(),
+  omnilingual: SherpaOnnxOfflineOmnilingualAsrCtcModelConfig =
+    sherpaOnnxOfflineOmnilingualAsrCtcModelConfig(),
+  medasr: SherpaOnnxOfflineMedAsrCtcModelConfig =
+    sherpaOnnxOfflineMedAsrCtcModelConfig(),
+  funasrNano: SherpaOnnxOfflineFunASRNanoModelConfig =
+    sherpaOnnxOfflineFunASRNanoModelConfig(),
+  fireRedAsrCtc: SherpaOnnxOfflineFireRedAsrCtcModelConfig =
+    sherpaOnnxOfflineFireRedAsrCtcModelConfig(),
+  qwen3Asr: SherpaOnnxOfflineQwen3ASRModelConfig =
+    sherpaOnnxOfflineQwen3ASRModelConfig(),
+  cohereTranscribe: SherpaOnnxOfflineCohereTranscribeModelConfig =
+    sherpaOnnxOfflineCohereTranscribeModelConfig()
+) -> SherpaOnnxOfflineModelConfig {
+  return SherpaOnnxOfflineModelConfig(
+    transducer: transducer,
+    paraformer: paraformer,
+    nemo_ctc: nemoCtc,
+    whisper: whisper,
+    tdnn: tdnn,
+    tokens: toCPointer(tokens),
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider),
+    model_type: toCPointer(modelType),
+    modeling_unit: toCPointer(modelingUnit),
+    bpe_vocab: toCPointer(bpeVocab),
+    telespeech_ctc: toCPointer(teleSpeechCtc),
+    sense_voice: senseVoice,
+    moonshine: moonshine,
+    fire_red_asr: fireRedAsr,
+    dolphin: dolphin,
+    zipformer_ctc: zipformerCtc,
+    canary: canary,
+    wenet_ctc: wenetCtc,
+    omnilingual: omnilingual,
+    medasr: medasr,
+    funasr_nano: funasrNano,
+    fire_red_asr_ctc: fireRedAsrCtc,
+    qwen3_asr: qwen3Asr,
+    cohere_transcribe: cohereTranscribe
+  )
+}
+
+func sherpaOnnxOfflineRecognizerConfig(
+  featConfig: SherpaOnnxFeatureConfig,
+  modelConfig: SherpaOnnxOfflineModelConfig,
+  lmConfig: SherpaOnnxOfflineLMConfig = sherpaOnnxOfflineLMConfig(),
+  decodingMethod: String = "greedy_search",
+  maxActivePaths: Int = 4,
+  hotwordsFile: String = "",
+  hotwordsScore: Float = 1.5,
+  ruleFsts: String = "",
+  ruleFars: String = "",
+  blankPenalty: Float = 0.0,
+  hr: SherpaOnnxHomophoneReplacerConfig = sherpaOnnxHomophoneReplacerConfig()
+) -> SherpaOnnxOfflineRecognizerConfig {
+  return SherpaOnnxOfflineRecognizerConfig(
+    feat_config: featConfig,
+    model_config: modelConfig,
+    lm_config: lmConfig,
+    decoding_method: toCPointer(decodingMethod),
+    max_active_paths: Int32(maxActivePaths),
+    hotwords_file: toCPointer(hotwordsFile),
+    hotwords_score: hotwordsScore,
+    rule_fsts: toCPointer(ruleFsts),
+    rule_fars: toCPointer(ruleFars),
+    blank_penalty: blankPenalty,
+    hr: hr
+  )
+}
+
+class SherpaOnnxOfflineRecongitionResult {
+  /// A pointer to the underlying counterpart in C
+  let result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>
+
+  private lazy var _text: String = {
+    guard let cstr = result.pointee.text else { return "" }
+    return String(cString: cstr)
+  }()
+
+  private lazy var _timestamps: [Float] = {
+    guard let p = result.pointee.timestamps else { return [] }
+    return (0..<result.pointee.count).map { p[Int($0)] }
+  }()
+
+  private lazy var _durations: [Float] = {
+    guard let p = result.pointee.durations else { return [] }
+    return (0..<result.pointee.count).map { p[Int($0)] }
+  }()
+
+  private lazy var _lang: String = {
+    guard let cstr = result.pointee.lang else { return "" }
+    return String(cString: cstr)
+  }()
+
+  private lazy var _emotion: String = {
+    guard let cstr = result.pointee.emotion else { return "" }
+    return String(cString: cstr)
+  }()
+
+  private lazy var _event: String = {
+    guard let cstr = result.pointee.event else { return "" }
+    return String(cString: cstr)
+  }()
+
+  private lazy var _segmentTimestamps: [Float] = {
+    guard let p = result.pointee.segment_timestamps else { return [] }
+    return (0..<result.pointee.segment_count).map { p[Int($0)] }
+  }()
+
+  private lazy var _segmentDurations: [Float] = {
+    guard let p = result.pointee.segment_durations else { return [] }
+    return (0..<result.pointee.segment_count).map { p[Int($0)] }
+  }()
+
+  private lazy var _segmentTexts: [String] = {
+    guard let arr = result.pointee.segment_texts_arr else { return [] }
+    return (0..<result.pointee.segment_count).compactMap { idx -> String? in
+      guard let ptr = arr[Int(idx)] else { return nil }
+      return String(cString: ptr)
+    }
+  }()
+
+  /// Return the actual recognition result.
+  /// For English models, it contains words separated by spaces.
+  /// For Chinese models, it contains Chinese words.
+  var text: String { _text }
+  var count: Int { Int(result.pointee.count) }
+  var timestamps: [Float] { _timestamps }
+
+  // Non-empty for TDT models. Empty for all other non-TDT models
+  var durations: [Float] { _durations }
+
+  // For SenseVoice models, it can be zh, en, ja, yue, ko
+  // where zh is for Chinese
+  // en is for English
+  // ja is for Japanese
+  // yue is for Cantonese
+  // ko is for Korean
+  var lang: String { _lang }
+
+  // for SenseVoice models
+  var emotion: String { _emotion }
+
+  // for SenseVoice models
+  var event: String { _event }
+
+  // Segment-level timestamps (for Whisper with segment timestamps enabled)
+  var segmentCount: Int { Int(result.pointee.segment_count) }
+  var segmentTimestamps: [Float] { _segmentTimestamps }
+  var segmentDurations: [Float] { _segmentDurations }
+  var segmentTexts: [String] { _segmentTexts }
+
+  init(result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>) {
+    self.result = result
+  }
+
+  deinit {
+    SherpaOnnxDestroyOfflineRecognizerResult(result)
+  }
+}
+
+class SherpaOnnxOfflineRecognizer {
+  /// A pointer to the underlying counterpart in C
+  private let recognizer: OpaquePointer
+
+  init(
+    config: UnsafePointer<SherpaOnnxOfflineRecognizerConfig>
+  ) {
+    guard let ptr = SherpaOnnxCreateOfflineRecognizer(config) else {
+      fatalError("Failed to create SherpaOnnxOfflineRecognizer")
+    }
+    self.recognizer = ptr
+  }
+
+  deinit {
+    SherpaOnnxDestroyOfflineRecognizer(recognizer)
+  }
+
+  /// Decode wave samples.
+  ///
+  /// - Parameters:
+  ///   - samples: Audio samples normalized to the range [-1, 1]
+  ///   - sampleRate: Sample rate of the input audio samples. Must match
+  ///                 the one expected by the model.
+  func decode(samples: [Float], sampleRate: Int = 16_000) -> SherpaOnnxOfflineRecongitionResult {
+    let stream = createStream()
+    stream.acceptWaveform(samples: samples, sampleRate: sampleRate)
+    decode(stream: stream)
+    return getResult(stream: stream)
+  }
+
+  func setConfig(config: UnsafePointer<SherpaOnnxOfflineRecognizerConfig>) {
+    SherpaOnnxOfflineRecognizerSetConfig(recognizer, config)
+  }
+
+  func createStream() -> SherpaOnnxOfflineStreamWrapper {
+    guard let stream = SherpaOnnxCreateOfflineStream(recognizer) else {
+      fatalError("Failed to create offline stream")
+    }
+
+    return SherpaOnnxOfflineStreamWrapper(stream: stream)
+  }
+
+  func decode(stream: SherpaOnnxOfflineStreamWrapper) {
+    SherpaOnnxDecodeOfflineStream(recognizer, stream.stream)
+  }
+
+  func getResult(stream: SherpaOnnxOfflineStreamWrapper) -> SherpaOnnxOfflineRecongitionResult {
+    guard let resultPtr = SherpaOnnxGetOfflineStreamResult(stream.stream) else {
+      fatalError("Failed to get offline recognition result")
+    }
+
+    return SherpaOnnxOfflineRecongitionResult(result: resultPtr)
+  }
+}
+
+class SherpaOnnxOfflineStreamWrapper {
+  let stream: OpaquePointer
+
+  init(stream: OpaquePointer) {
+    self.stream = stream
+  }
+
+  deinit {
+    SherpaOnnxDestroyOfflineStream(stream)
+  }
+
+  func setOption(key: String, value: String) {
+    SherpaOnnxOfflineStreamSetOption(stream, toCPointer(key), toCPointer(value))
+  }
+
+  func acceptWaveform(samples: [Float], sampleRate: Int = 16_000) {
+    SherpaOnnxAcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
+  }
+}
+
+func sherpaOnnxSileroVadModelConfig(
+  model: String = "",
+  threshold: Float = 0.5,
+  minSilenceDuration: Float = 0.25,
+  minSpeechDuration: Float = 0.5,
+  windowSize: Int = 512,
+  maxSpeechDuration: Float = 5.0
+) -> SherpaOnnxSileroVadModelConfig {
+  return SherpaOnnxSileroVadModelConfig(
+    model: toCPointer(model),
+    threshold: threshold,
+    min_silence_duration: minSilenceDuration,
+    min_speech_duration: minSpeechDuration,
+    window_size: Int32(windowSize),
+    max_speech_duration: maxSpeechDuration
+  )
+}
+
+func sherpaOnnxTenVadModelConfig(
+  model: String = "",
+  threshold: Float = 0.5,
+  minSilenceDuration: Float = 0.25,
+  minSpeechDuration: Float = 0.5,
+  windowSize: Int = 256,
+  maxSpeechDuration: Float = 5.0
+) -> SherpaOnnxTenVadModelConfig {
+  return SherpaOnnxTenVadModelConfig(
+    model: toCPointer(model),
+    threshold: threshold,
+    min_silence_duration: minSilenceDuration,
+    min_speech_duration: minSpeechDuration,
+    window_size: Int32(windowSize),
+    max_speech_duration: maxSpeechDuration
+  )
+}
+
+func sherpaOnnxVadModelConfig(
+  sileroVad: SherpaOnnxSileroVadModelConfig = sherpaOnnxSileroVadModelConfig(),
+  sampleRate: Int32 = 16000,
+  numThreads: Int = 1,
+  provider: String = "cpu",
+  debug: Int = 0,
+  tenVad: SherpaOnnxTenVadModelConfig = sherpaOnnxTenVadModelConfig()
+) -> SherpaOnnxVadModelConfig {
+  return SherpaOnnxVadModelConfig(
+    silero_vad: sileroVad,
+    sample_rate: sampleRate,
+    num_threads: Int32(numThreads),
+    provider: toCPointer(provider),
+    debug: Int32(debug),
+    ten_vad: tenVad
+  )
+}
+
+class SherpaOnnxCircularBufferWrapper {
+  private let buffer: OpaquePointer
+
+  init(capacity: Int) {
+    guard let ptr = SherpaOnnxCreateCircularBuffer(Int32(capacity)) else {
+      fatalError("Failed to create SherpaOnnxCircularBuffer")
+    }
+    self.buffer = ptr
+  }
+
+  deinit {
+    SherpaOnnxDestroyCircularBuffer(buffer)
+  }
+
+  func push(samples: [Float]) {
+    guard !samples.isEmpty else { return }
+    SherpaOnnxCircularBufferPush(buffer, samples, Int32(samples.count))
+  }
+
+  func get(startIndex: Int, n: Int) -> [Float] {
+    guard startIndex >= 0 else { return [] }
+    guard n > 0 else { return [] }
+
+    guard let ptr = SherpaOnnxCircularBufferGet(buffer, Int32(startIndex), Int32(n)) else {
+      return []
+    }
+    defer { SherpaOnnxCircularBufferFree(ptr) }
+
+    return Array(UnsafeBufferPointer(start: ptr, count: n))
+  }
+
+  func pop(n: Int) {
+    guard n > 0 else { return }
+    SherpaOnnxCircularBufferPop(buffer, Int32(n))
+  }
+
+  func size() -> Int {
+    return Int(SherpaOnnxCircularBufferSize(buffer))
+  }
+
+  func reset() {
+    SherpaOnnxCircularBufferReset(buffer)
+  }
+}
+
+class SherpaOnnxSpeechSegmentWrapper {
+  private let p: UnsafePointer<SherpaOnnxSpeechSegment>
+
+  init(p: UnsafePointer<SherpaOnnxSpeechSegment>) {
+    self.p = p
+  }
+
+  deinit {
+    SherpaOnnxDestroySpeechSegment(p)
+  }
+
+  var start: Int {
+    Int(p.pointee.start)
+  }
+
+  var n: Int {
+    Int(p.pointee.n)
+  }
+
+  lazy var samples: [Float] = {
+    Array(UnsafeBufferPointer(start: p.pointee.samples, count: n))
+  }()
+}
+
+class SherpaOnnxVoiceActivityDetectorWrapper {
+  /// A pointer to the underlying counterpart in C
+  private let vad: OpaquePointer
+
+  init(config: UnsafePointer<SherpaOnnxVadModelConfig>, buffer_size_in_seconds: Float) {
+    guard let vad = SherpaOnnxCreateVoiceActivityDetector(config, buffer_size_in_seconds) else {
+      fatalError("SherpaOnnxCreateVoiceActivityDetector returned nil")
+    }
+    self.vad = vad
+  }
+
+  deinit {
+    SherpaOnnxDestroyVoiceActivityDetector(vad)
+  }
+
+  func acceptWaveform(samples: [Float]) {
+    SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, samples, Int32(samples.count))
+  }
+
+  func isEmpty() -> Bool {
+    return SherpaOnnxVoiceActivityDetectorEmpty(vad) == 1
+  }
+
+  func isSpeechDetected() -> Bool {
+    return SherpaOnnxVoiceActivityDetectorDetected(vad) == 1
+  }
+
+  func pop() {
+    SherpaOnnxVoiceActivityDetectorPop(vad)
+  }
+
+  func clear() {
+    SherpaOnnxVoiceActivityDetectorClear(vad)
+  }
+
+  func front() -> SherpaOnnxSpeechSegmentWrapper {
+    guard let p = SherpaOnnxVoiceActivityDetectorFront(vad) else {
+      fatalError("SherpaOnnxVoiceActivityDetectorFront returned nil")
+    }
+    return SherpaOnnxSpeechSegmentWrapper(p: p)
+  }
+
+  func reset() {
+    SherpaOnnxVoiceActivityDetectorReset(vad)
+  }
+
+  func flush() {
+    SherpaOnnxVoiceActivityDetectorFlush(vad)
+  }
+}
+
+// offline tts
+func sherpaOnnxOfflineTtsVitsModelConfig(
+  model: String = "",
+  lexicon: String = "",
+  tokens: String = "",
+  dataDir: String = "",
+  noiseScale: Float = 0.667,
+  noiseScaleW: Float = 0.8,
+  lengthScale: Float = 1.0,
+  dictDir: String = ""
+) -> SherpaOnnxOfflineTtsVitsModelConfig {
+  return SherpaOnnxOfflineTtsVitsModelConfig(
+    model: toCPointer(model),
+    lexicon: toCPointer(lexicon),
+    tokens: toCPointer(tokens),
+    data_dir: toCPointer(dataDir),
+    noise_scale: noiseScale,
+    noise_scale_w: noiseScaleW,
+    length_scale: lengthScale,
+    dict_dir: toCPointer(dictDir)
+  )
+}
+
+func sherpaOnnxOfflineTtsMatchaModelConfig(
+  acousticModel: String = "",
+  vocoder: String = "",
+  lexicon: String = "",
+  tokens: String = "",
+  dataDir: String = "",
+  noiseScale: Float = 0.667,
+  lengthScale: Float = 1.0,
+  dictDir: String = ""
+) -> SherpaOnnxOfflineTtsMatchaModelConfig {
+  return SherpaOnnxOfflineTtsMatchaModelConfig(
+    acoustic_model: toCPointer(acousticModel),
+    vocoder: toCPointer(vocoder),
+    lexicon: toCPointer(lexicon),
+    tokens: toCPointer(tokens),
+    data_dir: toCPointer(dataDir),
+    noise_scale: noiseScale,
+    length_scale: lengthScale,
+    dict_dir: toCPointer(dictDir)
+  )
+}
+
+func sherpaOnnxOfflineTtsKokoroModelConfig(
+  model: String = "",
+  voices: String = "",
+  tokens: String = "",
+  dataDir: String = "",
+  lengthScale: Float = 1.0,
+  dictDir: String = "",
+  lexicon: String = "",
+  lang: String = ""
+) -> SherpaOnnxOfflineTtsKokoroModelConfig {
+  return SherpaOnnxOfflineTtsKokoroModelConfig(
+    model: toCPointer(model),
+    voices: toCPointer(voices),
+    tokens: toCPointer(tokens),
+    data_dir: toCPointer(dataDir),
+    length_scale: lengthScale,
+    dict_dir: toCPointer(dictDir),
+    lexicon: toCPointer(lexicon),
+    lang: toCPointer(lang)
+  )
+}
+
+func sherpaOnnxOfflineTtsKittenModelConfig(
+  model: String = "",
+  voices: String = "",
+  tokens: String = "",
+  dataDir: String = "",
+  lengthScale: Float = 1.0
+) -> SherpaOnnxOfflineTtsKittenModelConfig {
+  return SherpaOnnxOfflineTtsKittenModelConfig(
+    model: toCPointer(model),
+    voices: toCPointer(voices),
+    tokens: toCPointer(tokens),
+    data_dir: toCPointer(dataDir),
+    length_scale: lengthScale
+  )
+}
+
+func sherpaOnnxOfflineTtsZipvoiceModelConfig(
+  tokens: String = "",
+  encoder: String = "",
+  decoder: String = "",
+  vocoder: String = "",
+  dataDir: String = "",
+  lexicon: String = "",
+  featScale: Float = 0.1,
+  tShift: Float = 0.5,
+  targetRms: Float = 0.1,
+  guidanceScale: Float = 1.0
+) -> SherpaOnnxOfflineTtsZipvoiceModelConfig {
+  return SherpaOnnxOfflineTtsZipvoiceModelConfig(
+    tokens: toCPointer(tokens),
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    vocoder: toCPointer(vocoder),
+    data_dir: toCPointer(dataDir),
+    lexicon: toCPointer(lexicon),
+    feat_scale: featScale,
+    t_shift: tShift,
+    target_rms: targetRms,
+    guidance_scale: guidanceScale
+  )
+}
+
+func sherpaOnnxOfflineTtsPocketModelConfig(
+  lmFlow: String = "",
+  lmMain: String = "",
+  encoder: String = "",
+  decoder: String = "",
+  textConditioner: String = "",
+  vocabJson: String = "",
+  tokenScoresJson: String = "",
+  voiceEmbeddingCacheCapacity: Int = 50
+) -> SherpaOnnxOfflineTtsPocketModelConfig {
+  return SherpaOnnxOfflineTtsPocketModelConfig(
+    lm_flow: toCPointer(lmFlow),
+    lm_main: toCPointer(lmMain),
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    text_conditioner: toCPointer(textConditioner),
+    vocab_json: toCPointer(vocabJson),
+    token_scores_json: toCPointer(tokenScoresJson),
+    voice_embedding_cache_capacity: Int32(voiceEmbeddingCacheCapacity)
+  )
+}
+
+func sherpaOnnxOfflineTtsSupertonicModelConfig(
+  durationPredictor: String = "",
+  textEncoder: String = "",
+  vectorEstimator: String = "",
+  vocoder: String = "",
+  ttsJson: String = "",
+  unicodeIndexer: String = "",
+  voiceStyle: String = ""
+) -> SherpaOnnxOfflineTtsSupertonicModelConfig {
+  return SherpaOnnxOfflineTtsSupertonicModelConfig(
+    duration_predictor: toCPointer(durationPredictor),
+    text_encoder: toCPointer(textEncoder),
+    vector_estimator: toCPointer(vectorEstimator),
+    vocoder: toCPointer(vocoder),
+    tts_json: toCPointer(ttsJson),
+    unicode_indexer: toCPointer(unicodeIndexer),
+    voice_style: toCPointer(voiceStyle)
+  )
+}
+
+func sherpaOnnxOfflineTtsModelConfig(
+  vits: SherpaOnnxOfflineTtsVitsModelConfig = sherpaOnnxOfflineTtsVitsModelConfig(),
+  matcha: SherpaOnnxOfflineTtsMatchaModelConfig = sherpaOnnxOfflineTtsMatchaModelConfig(),
+  kokoro: SherpaOnnxOfflineTtsKokoroModelConfig = sherpaOnnxOfflineTtsKokoroModelConfig(),
+  numThreads: Int = 1,
+  debug: Int = 0,
+  provider: String = "cpu",
+  kitten: SherpaOnnxOfflineTtsKittenModelConfig = sherpaOnnxOfflineTtsKittenModelConfig(),
+  zipvoice: SherpaOnnxOfflineTtsZipvoiceModelConfig = sherpaOnnxOfflineTtsZipvoiceModelConfig(),
+  pocket: SherpaOnnxOfflineTtsPocketModelConfig = sherpaOnnxOfflineTtsPocketModelConfig(),
+  supertonic: SherpaOnnxOfflineTtsSupertonicModelConfig =
+    sherpaOnnxOfflineTtsSupertonicModelConfig()
+) -> SherpaOnnxOfflineTtsModelConfig {
+  return SherpaOnnxOfflineTtsModelConfig(
+    vits: vits,
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider),
+    matcha: matcha,
+    kokoro: kokoro,
+    kitten: kitten,
+    zipvoice: zipvoice,
+    pocket: pocket,
+    supertonic: supertonic
+  )
+}
+
+func sherpaOnnxOfflineTtsConfig(
+  model: SherpaOnnxOfflineTtsModelConfig,
+  ruleFsts: String = "",
+  ruleFars: String = "",
+  maxNumSentences: Int = 1,
+  silenceScale: Float = 0.2
+) -> SherpaOnnxOfflineTtsConfig {
+  return SherpaOnnxOfflineTtsConfig(
+    model: model,
+    rule_fsts: toCPointer(ruleFsts),
+    max_num_sentences: Int32(maxNumSentences),
+    rule_fars: toCPointer(ruleFars),
+    silence_scale: silenceScale
+  )
+}
+
+class SherpaOnnxWaveWrapper {
+  let wave: UnsafePointer<SherpaOnnxWave>!
+
+  class func readWave(filename: String) -> SherpaOnnxWaveWrapper {
+    let wave = SherpaOnnxReadWave(toCPointer(filename))
+    return SherpaOnnxWaveWrapper(wave: wave)
+  }
+
+  init(wave: UnsafePointer<SherpaOnnxWave>!) {
+    self.wave = wave
+  }
+
+  deinit {
+    if let wave {
+      SherpaOnnxFreeWave(wave)
+    }
+  }
+
+  var numSamples: Int {
+    return Int(wave.pointee.num_samples)
+  }
+
+  var sampleRate: Int {
+    return Int(wave.pointee.sample_rate)
+  }
+
+  var samples: [Float] {
+    if numSamples == 0 {
+      return []
+    } else {
+      return [Float](UnsafeBufferPointer(start: wave.pointee.samples, count: numSamples))
+    }
+  }
+}
+
+class SherpaOnnxGeneratedAudioWrapper {
+  /// A pointer to the underlying counterpart in C
+  let audio: UnsafePointer<SherpaOnnxGeneratedAudio>!
+
+  init(audio: UnsafePointer<SherpaOnnxGeneratedAudio>!) {
+    self.audio = audio
+  }
+
+  deinit {
+    if let audio {
+      SherpaOnnxDestroyOfflineTtsGeneratedAudio(audio)
+    }
+  }
+
+  var n: Int32 {
+    return audio.pointee.n
+  }
+
+  var sampleRate: Int32 {
+    return audio.pointee.sample_rate
+  }
+
+  var samples: [Float] {
+    if let p = audio.pointee.samples {
+      return [Float](UnsafeBufferPointer(start: p, count: Int(n)))
+    } else {
+      return []
+    }
+  }
+
+  func save(filename: String) -> Int32 {
+    return SherpaOnnxWriteWave(audio.pointee.samples, n, sampleRate, toCPointer(filename))
+  }
+}
+
+typealias TtsCallbackWithArg = (
+  @convention(c) (
+    UnsafePointer<Float>?,  // const float* samples
+    Int32,  // int32_t n
+    UnsafeMutableRawPointer?  // void *arg
+  ) -> Int32
+)?
+
+class SherpaOnnxCallbackPair {
+  var cb: TtsCallbackWithArg
+  var arg: UnsafeMutableRawPointer?
+  init(cb: TtsCallbackWithArg, arg: UnsafeMutableRawPointer?) {
+    self.cb = cb
+    self.arg = arg
+  }
+}
+
+typealias TtsProgressCallbackWithArg =
+  @convention(c) (
+    UnsafePointer<Float>?, Int32, Float, UnsafeMutableRawPointer?
+  ) -> Int32
+
+struct SherpaOnnxGenerationConfigSwift {
+  var silenceScale: Float = 0.2
+  var speed: Float = 1.0
+  var sid: Int = 0
+  var referenceAudio: [Float] = []
+  var referenceSampleRate: Int = 16000
+  var referenceText: String = ""
+  var numSteps: Int = 1
+  var extra: [String: Any] = [:]  // Any can be String, Int, Float, Double
+
+  /// Convert the extra dictionary into a JSON string
+  func extraJsonString() -> String {
+    var jsonCompatible: [String: Any] = [:]
+
+    for (key, value) in extra {
+      switch value {
+      case let v as String:
+        jsonCompatible[key] = v
+      case let v as Int:
+        jsonCompatible[key] = v
+      case let v as Float:
+        jsonCompatible[key] = v
+      case let v as Double:
+        jsonCompatible[key] = v
+      default:
+        // ignore unsupported types
+        print("Warning: unsupported type for key '\(key)' in extra")
+      }
+    }
+
+    guard let data = try? JSONSerialization.data(withJSONObject: jsonCompatible, options: []),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+
+    return json
+  }
+}
+final class SherpaOnnxGenerationConfigC {
+  /// The underlying C struct
+  var cConfig: SherpaOnnxGenerationConfig
+
+  /// Storage for reference audio so the pointer stays valid during the C call
+  private let referenceAudioStorage: [Float]
+
+  /// Extra JSON string for C API
+  let extraJson: String
+
+  init(_ swiftConfig: SherpaOnnxGenerationConfigSwift) {
+    let referenceAudio = swiftConfig.referenceAudio
+
+    let extraJson = swiftConfig.extraJsonString()
+    self.extraJson = extraJson
+
+    self.referenceAudioStorage = referenceAudio
+
+    self.cConfig = self.referenceAudioStorage.withUnsafeBufferPointer { buffer in
+      SherpaOnnxGenerationConfig(
+        silence_scale: swiftConfig.silenceScale,
+        speed: swiftConfig.speed,
+        sid: Int32(swiftConfig.sid),
+        reference_audio: buffer.count > 0 ? buffer.baseAddress : nil,
+        reference_audio_len: Int32(buffer.count),
+        reference_sample_rate: Int32(swiftConfig.referenceSampleRate),
+        reference_text: toCPointer(swiftConfig.referenceText),
+        num_steps: Int32(swiftConfig.numSteps),
+        extra: toCPointer(extraJson)
+      )
+    }
+  }
+}
+
+class SherpaOnnxOfflineTtsWrapper {
+  /// A pointer to the underlying counterpart in C
+  let tts: OpaquePointer!
+
+  /// Whether the model is a Supertonic TTS model
+  let isSupertonic: Bool
+
+  /// The sample rate of the generated audio
+  var sampleRate: Int32 {
+    return SherpaOnnxOfflineTtsSampleRate(tts)
+  }
+
+  /// The number of speakers supported by the model
+  var numSpeakers: Int32 {
+    return SherpaOnnxOfflineTtsNumSpeakers(tts)
+  }
+
+  /// Constructor taking a model config
+  init(
+    config: UnsafePointer<SherpaOnnxOfflineTtsConfig>!
+  ) {
+    isSupertonic = config.pointee.model.supertonic.duration_predictor != nil
+      && config.pointee.model.supertonic.duration_predictor.pointee != 0
+    tts = SherpaOnnxCreateOfflineTts(config)
+  }
+
+  deinit {
+    if let tts {
+      SherpaOnnxDestroyOfflineTts(tts)
+    }
+  }
+
+  func generate(text: String, sid: Int = 0, speed: Float = 1.0) -> SherpaOnnxGeneratedAudioWrapper {
+    let config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
+    return generateWithConfig(text: text, config: config, callback: nil, arg: nil)
+  }
+
+  func generateWithCallbackWithArg(
+    text: String, callback: TtsCallbackWithArg, arg: UnsafeMutableRawPointer, sid: Int = 0,
+    speed: Float = 1.0
+  ) -> SherpaOnnxGeneratedAudioWrapper {
+    let config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
+
+    let pair = SherpaOnnxCallbackPair(cb: callback, arg: arg)
+    let unmanaged = Unmanaged.passRetained(pair)
+    let wrapper: TtsProgressCallbackWithArg = { samples, n, progress, rawArg in
+      let p = Unmanaged<SherpaOnnxCallbackPair>.fromOpaque(rawArg!).takeUnretainedValue()
+      return p.cb!(samples, n, p.arg)
+    }
+    let result = generateWithConfig(
+      text: text, config: config, callback: wrapper, arg: unmanaged.toOpaque())
+    unmanaged.release()
+    return result
+  }
+
+  func generateWithConfig(
+    text: String,
+    config: SherpaOnnxGenerationConfigSwift,
+    callback: TtsProgressCallbackWithArg?,
+    arg: UnsafeMutableRawPointer?
+  ) -> SherpaOnnxGeneratedAudioWrapper {
+    let bridge = SherpaOnnxGenerationConfigC(config)
+
+    let audio: UnsafePointer<SherpaOnnxGeneratedAudio>? =
+      withUnsafePointer(to: &bridge.cConfig) { configPtr in
+        SherpaOnnxOfflineTtsGenerateWithConfig(
+          tts,
+          toCPointer(text),
+          configPtr,
+          callback,
+          arg
+        )
+      }
+
+    return SherpaOnnxGeneratedAudioWrapper(audio: audio)
+  }
+
+}
+
+// spoken language identification
+
+func sherpaOnnxSpokenLanguageIdentificationWhisperConfig(
+  encoder: String,
+  decoder: String,
+  tailPaddings: Int = -1
+) -> SherpaOnnxSpokenLanguageIdentificationWhisperConfig {
+  return SherpaOnnxSpokenLanguageIdentificationWhisperConfig(
+    encoder: toCPointer(encoder),
+    decoder: toCPointer(decoder),
+    tail_paddings: Int32(tailPaddings))
+}
+
+func sherpaOnnxSpokenLanguageIdentificationConfig(
+  whisper: SherpaOnnxSpokenLanguageIdentificationWhisperConfig,
+  numThreads: Int = 1,
+  debug: Int = 0,
+  provider: String = "cpu"
+) -> SherpaOnnxSpokenLanguageIdentificationConfig {
+  return SherpaOnnxSpokenLanguageIdentificationConfig(
+    whisper: whisper,
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider))
+}
+
+class SherpaOnnxSpokenLanguageIdentificationResultWrapper {
+  /// A pointer to the underlying counterpart in C
+  let result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>!
+
+  /// Return the detected language.
+  /// en for English
+  /// zh for Chinese
+  /// es for Spanish
+  /// de for German
+  /// etc.
+  var lang: String {
+    return String(cString: result.pointee.lang)
+  }
+
+  init(result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>!) {
+    self.result = result
+  }
+
+  deinit {
+    if let result {
+      SherpaOnnxDestroySpokenLanguageIdentificationResult(result)
+    }
+  }
+}
+
+class SherpaOnnxSpokenLanguageIdentificationWrapper {
+  /// A pointer to the underlying counterpart in C
+  let slid: OpaquePointer!
+
+  init(
+    config: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationConfig>!
+  ) {
+    slid = SherpaOnnxCreateSpokenLanguageIdentification(config)
+  }
+
+  deinit {
+    if let slid {
+      SherpaOnnxDestroySpokenLanguageIdentification(slid)
+    }
+  }
+
+  func decode(samples: [Float], sampleRate: Int = 16000)
+    -> SherpaOnnxSpokenLanguageIdentificationResultWrapper
+  {
+    let stream: OpaquePointer! = SherpaOnnxSpokenLanguageIdentificationCreateOfflineStream(slid)
+    SherpaOnnxAcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
+
+    let result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>? =
+      SherpaOnnxSpokenLanguageIdentificationCompute(
+        slid,
+        stream)
+
+    SherpaOnnxDestroyOfflineStream(stream)
+    return SherpaOnnxSpokenLanguageIdentificationResultWrapper(result: result)
+  }
+}
+
+// keyword spotting
+
+class SherpaOnnxKeywordResultWrapper {
+  /// A pointer to the underlying counterpart in C
+  let result: UnsafePointer<SherpaOnnxKeywordResult>!
+
+  var keyword: String {
+    return String(cString: result.pointee.keyword)
+  }
+
+  var count: Int32 {
+    return result.pointee.count
+  }
+
+  var tokens: [String] {
+    if let tokensPointer = result.pointee.tokens_arr {
+      var tokens: [String] = []
+      for index in 0..<count {
+        if let tokenPointer = tokensPointer[Int(index)] {
+          let token = String(cString: tokenPointer)
+          tokens.append(token)
+        }
+      }
+      return tokens
+    } else {
+      let tokens: [String] = []
+      return tokens
+    }
+  }
+
+  init(result: UnsafePointer<SherpaOnnxKeywordResult>!) {
+    self.result = result
+  }
+
+  deinit {
+    if let result {
+      SherpaOnnxDestroyKeywordResult(result)
+    }
+  }
+}
+
+func sherpaOnnxKeywordSpotterConfig(
+  featConfig: SherpaOnnxFeatureConfig,
+  modelConfig: SherpaOnnxOnlineModelConfig,
+  keywordsFile: String,
+  maxActivePaths: Int = 4,
+  numTrailingBlanks: Int = 1,
+  keywordsScore: Float = 1.0,
+  keywordsThreshold: Float = 0.25,
+  keywordsBuf: String = "",
+  keywordsBufSize: Int = 0
+) -> SherpaOnnxKeywordSpotterConfig {
+  return SherpaOnnxKeywordSpotterConfig(
+    feat_config: featConfig,
+    model_config: modelConfig,
+    max_active_paths: Int32(maxActivePaths),
+    num_trailing_blanks: Int32(numTrailingBlanks),
+    keywords_score: keywordsScore,
+    keywords_threshold: keywordsThreshold,
+    keywords_file: toCPointer(keywordsFile),
+    keywords_buf: toCPointer(keywordsBuf),
+    keywords_buf_size: Int32(keywordsBufSize)
+  )
+}
+
+class SherpaOnnxKeywordSpotterWrapper {
+  /// A pointer to the underlying counterpart in C
+  let spotter: OpaquePointer!
+  var stream: OpaquePointer!
+
+  init(
+    config: UnsafePointer<SherpaOnnxKeywordSpotterConfig>!
+  ) {
+    spotter = SherpaOnnxCreateKeywordSpotter(config)
+    stream = SherpaOnnxCreateKeywordStream(spotter)
+  }
+
+  deinit {
+    if let stream {
+      SherpaOnnxDestroyOnlineStream(stream)
+    }
+
+    if let spotter {
+      SherpaOnnxDestroyKeywordSpotter(spotter)
+    }
+  }
+
+  func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
+  }
+
+  func isReady() -> Bool {
+    return SherpaOnnxIsKeywordStreamReady(spotter, stream) == 1 ? true : false
+  }
+
+  func decode() {
+    SherpaOnnxDecodeKeywordStream(spotter, stream)
+  }
+
+  func reset() {
+    SherpaOnnxResetKeywordStream(spotter, stream)
+  }
+
+  func getResult() -> SherpaOnnxKeywordResultWrapper {
+    let result: UnsafePointer<SherpaOnnxKeywordResult>? = SherpaOnnxGetKeywordResult(
+      spotter, stream)
+    return SherpaOnnxKeywordResultWrapper(result: result)
+  }
+
+  /// Signal that no more audio samples would be available.
+  /// After this call, you cannot call acceptWaveform() any more.
+  func inputFinished() {
+    SherpaOnnxOnlineStreamInputFinished(stream)
+  }
+}
+
+// Punctuation
+
+func sherpaOnnxOfflinePunctuationModelConfig(
+  ctTransformer: String,
+  numThreads: Int = 1,
+  debug: Int = 0,
+  provider: String = "cpu"
+) -> SherpaOnnxOfflinePunctuationModelConfig {
+  return SherpaOnnxOfflinePunctuationModelConfig(
+    ct_transformer: toCPointer(ctTransformer),
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider)
+  )
+}
+
+func sherpaOnnxOfflinePunctuationConfig(
+  model: SherpaOnnxOfflinePunctuationModelConfig
+) -> SherpaOnnxOfflinePunctuationConfig {
+  return SherpaOnnxOfflinePunctuationConfig(
+    model: model
+  )
+}
+
+class SherpaOnnxOfflinePunctuationWrapper {
+  /// A pointer to the underlying counterpart in C
+  let ptr: OpaquePointer!
+
+  /// Constructor taking a model config
+  init(
+    config: UnsafePointer<SherpaOnnxOfflinePunctuationConfig>!
+  ) {
+    ptr = SherpaOnnxCreateOfflinePunctuation(config)
+  }
+
+  deinit {
+    if let ptr {
+      SherpaOnnxDestroyOfflinePunctuation(ptr)
+    }
+  }
+
+  func addPunct(text: String) -> String {
+    let cText = SherpaOfflinePunctuationAddPunct(ptr, toCPointer(text))
+    let ans = String(cString: cText!)
+    SherpaOfflinePunctuationFreeText(cText)
+    return ans
+  }
+}
+
+func sherpaOnnxOnlinePunctuationModelConfig(
+  cnnBiLstm: String,
+  bpeVocab: String,
+  numThreads: Int = 1,
+  debug: Int = 0,
+  provider: String = "cpu"
+) -> SherpaOnnxOnlinePunctuationModelConfig {
+  return SherpaOnnxOnlinePunctuationModelConfig(
+    cnn_bilstm: toCPointer(cnnBiLstm),
+    bpe_vocab: toCPointer(bpeVocab),
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider))
+}
+
+func sherpaOnnxOnlinePunctuationConfig(
+  model: SherpaOnnxOnlinePunctuationModelConfig
+) -> SherpaOnnxOnlinePunctuationConfig {
+  return SherpaOnnxOnlinePunctuationConfig(model: model)
+}
+
+class SherpaOnnxOnlinePunctuationWrapper {
+  /// A pointer to the underlying counterpart in C
+  let ptr: OpaquePointer!
+
+  /// Constructor taking a model config
+  init(
+    config: UnsafePointer<SherpaOnnxOnlinePunctuationConfig>!
+  ) {
+    ptr = SherpaOnnxCreateOnlinePunctuation(config)
+  }
+
+  deinit {
+    if let ptr {
+      SherpaOnnxDestroyOnlinePunctuation(ptr)
+    }
+  }
+
+  func addPunct(text: String) -> String {
+    let cText = SherpaOnnxOnlinePunctuationAddPunct(ptr, toCPointer(text))
+    let ans = String(cString: cText!)
+    SherpaOnnxOnlinePunctuationFreeText(cText)
+    return ans
+  }
+}
+
+func sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: String)
+  -> SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig
+{
+  return SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: toCPointer(model))
+}
+
+func sherpaOnnxOfflineSpeakerSegmentationModelConfig(
+  pyannote: SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig,
+  numThreads: Int = 1,
+  debug: Int = 0,
+  provider: String = "cpu"
+) -> SherpaOnnxOfflineSpeakerSegmentationModelConfig {
+  return SherpaOnnxOfflineSpeakerSegmentationModelConfig(
+    pyannote: pyannote,
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider)
+  )
+}
+
+func sherpaOnnxFastClusteringConfig(numClusters: Int = -1, threshold: Float = 0.5)
+  -> SherpaOnnxFastClusteringConfig
+{
+  return SherpaOnnxFastClusteringConfig(num_clusters: Int32(numClusters), threshold: threshold)
+}
+
+func sherpaOnnxSpeakerEmbeddingExtractorConfig(
+  model: String,
+  numThreads: Int = 1,
+  debug: Int = 0,
+  provider: String = "cpu"
+) -> SherpaOnnxSpeakerEmbeddingExtractorConfig {
+  return SherpaOnnxSpeakerEmbeddingExtractorConfig(
+    model: toCPointer(model),
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider)
+  )
+}
+
+func sherpaOnnxOfflineSpeakerDiarizationConfig(
+  segmentation: SherpaOnnxOfflineSpeakerSegmentationModelConfig,
+  embedding: SherpaOnnxSpeakerEmbeddingExtractorConfig,
+  clustering: SherpaOnnxFastClusteringConfig,
+  minDurationOn: Float = 0.3,
+  minDurationOff: Float = 0.5
+) -> SherpaOnnxOfflineSpeakerDiarizationConfig {
+  return SherpaOnnxOfflineSpeakerDiarizationConfig(
+    segmentation: segmentation,
+    embedding: embedding,
+    clustering: clustering,
+    min_duration_on: minDurationOn,
+    min_duration_off: minDurationOff
+  )
+}
+
+struct SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper {
+  var start: Float = 0
+  var end: Float = 0
+  var speaker: Int = 0
+}
+
+class SherpaOnnxOfflineSpeakerDiarizationWrapper {
+  /// A pointer to the underlying counterpart in C
+  let impl: OpaquePointer!
+
+  init(
+    config: UnsafePointer<SherpaOnnxOfflineSpeakerDiarizationConfig>!
+  ) {
+    impl = SherpaOnnxCreateOfflineSpeakerDiarization(config)
+  }
+
+  deinit {
+    if let impl {
+      SherpaOnnxDestroyOfflineSpeakerDiarization(impl)
+    }
+  }
+
+  var sampleRate: Int {
+    return Int(SherpaOnnxOfflineSpeakerDiarizationGetSampleRate(impl))
+  }
+
+  // only config.clustering is used. All other fields are ignored
+  func setConfig(config: UnsafePointer<SherpaOnnxOfflineSpeakerDiarizationConfig>!) {
+    SherpaOnnxOfflineSpeakerDiarizationSetConfig(impl, config)
+  }
+
+  func process(samples: [Float]) -> [SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper] {
+    let result = SherpaOnnxOfflineSpeakerDiarizationProcess(
+      impl, samples, Int32(samples.count))
+
+    if result == nil {
+      return []
+    }
+
+    let numSegments = Int(SherpaOnnxOfflineSpeakerDiarizationResultGetNumSegments(result))
+
+    let p: UnsafePointer<SherpaOnnxOfflineSpeakerDiarizationSegment>? =
+      SherpaOnnxOfflineSpeakerDiarizationResultSortByStartTime(result)
+
+    if p == nil {
+      return []
+    }
+
+    var ans: [SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper] = []
+    for i in 0..<numSegments {
+      ans.append(
+        SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper(
+          start: p![i].start, end: p![i].end, speaker: Int(p![i].speaker)))
+    }
+
+    SherpaOnnxOfflineSpeakerDiarizationDestroySegment(p)
+    SherpaOnnxOfflineSpeakerDiarizationDestroyResult(result)
+
+    return ans
+  }
+}
+
+class SherpaOnnxOnlineStreamWrapper {
+  /// A pointer to the underlying counterpart in C
+  let impl: OpaquePointer!
+  init(impl: OpaquePointer!) {
+    self.impl = impl
+  }
+
+  deinit {
+    if let impl {
+      SherpaOnnxDestroyOnlineStream(impl)
+    }
+  }
+
+  func setOption(key: String, value: String) {
+    SherpaOnnxOnlineStreamSetOption(impl, toCPointer(key), toCPointer(value))
+  }
+
+  func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
+    SherpaOnnxOnlineStreamAcceptWaveform(impl, Int32(sampleRate), samples, Int32(samples.count))
+  }
+
+  func inputFinished() {
+    SherpaOnnxOnlineStreamInputFinished(impl)
+  }
+}
+
+class SherpaOnnxSpeakerEmbeddingExtractorWrapper {
+  /// A pointer to the underlying counterpart in C
+  let impl: OpaquePointer!
+
+  init(
+    config: UnsafePointer<SherpaOnnxSpeakerEmbeddingExtractorConfig>!
+  ) {
+    impl = SherpaOnnxCreateSpeakerEmbeddingExtractor(config)
+  }
+
+  deinit {
+    if let impl {
+      SherpaOnnxDestroySpeakerEmbeddingExtractor(impl)
+    }
+  }
+
+  var dim: Int {
+    return Int(SherpaOnnxSpeakerEmbeddingExtractorDim(impl))
+  }
+
+  func createStream() -> SherpaOnnxOnlineStreamWrapper {
+    let newStream = SherpaOnnxSpeakerEmbeddingExtractorCreateStream(impl)
+    return SherpaOnnxOnlineStreamWrapper(impl: newStream)
+  }
+
+  func isReady(stream: SherpaOnnxOnlineStreamWrapper) -> Bool {
+    return SherpaOnnxSpeakerEmbeddingExtractorIsReady(impl, stream.impl) == 1 ? true : false
+  }
+
+  func compute(stream: SherpaOnnxOnlineStreamWrapper) -> [Float] {
+    if !isReady(stream: stream) {
+      return []
+    }
+
+    let p = SherpaOnnxSpeakerEmbeddingExtractorComputeEmbedding(impl, stream.impl)
+
+    defer {
+      SherpaOnnxSpeakerEmbeddingExtractorDestroyEmbedding(p)
+    }
+
+    return [Float](UnsafeBufferPointer(start: p, count: dim))
+  }
+}
+
+func sherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(model: String = "")
+  -> SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig
+{
+  return SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(model: toCPointer(model))
+}
+
+func sherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig(model: String = "")
+  -> SherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig
+{
+  return SherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig(model: toCPointer(model))
+}
+
+func sherpaOnnxOfflineSpeechDenoiserModelConfig(
+  gtcrn: SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig =
+    sherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(),
+  dpdfnet: SherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig =
+    sherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig(),
+  numThreads: Int = 1,
+  provider: String = "cpu",
+  debug: Int = 0
+) -> SherpaOnnxOfflineSpeechDenoiserModelConfig {
+  return SherpaOnnxOfflineSpeechDenoiserModelConfig(
+    gtcrn: gtcrn,
+    num_threads: Int32(numThreads),
+    debug: Int32(debug),
+    provider: toCPointer(provider),
+    dpdfnet: dpdfnet
+  )
+}
+
+func sherpaOnnxOfflineSpeechDenoiserConfig(
+  model: SherpaOnnxOfflineSpeechDenoiserModelConfig =
+    sherpaOnnxOfflineSpeechDenoiserModelConfig()
+) -> SherpaOnnxOfflineSpeechDenoiserConfig {
+  return SherpaOnnxOfflineSpeechDenoiserConfig(
+    model: model)
+}
+
+class SherpaOnnxDenoisedAudioWrapper {
+  /// A pointer to the underlying counterpart in C
+  let audio: UnsafePointer<SherpaOnnxDenoisedAudio>!
+
+  init(audio: UnsafePointer<SherpaOnnxDenoisedAudio>!) {
+    self.audio = audio
+  }
+
+  deinit {
+    if let audio {
+      SherpaOnnxDestroyDenoisedAudio(audio)
+    }
+  }
+
+  var n: Int32 {
+    guard let audio else {
+      return 0
+    }
+    return audio.pointee.n
+  }
+
+  var sampleRate: Int32 {
+    guard let audio else {
+      return 0
+    }
+    return audio.pointee.sample_rate
+  }
+
+  var samples: [Float] {
+    guard let audio else {
+      return []
+    }
+
+    if let p = audio.pointee.samples {
+      var samples: [Float] = []
+      for index in 0..<n {
+        samples.append(p[Int(index)])
+      }
+      return samples
+    } else {
+      let samples: [Float] = []
+      return samples
+    }
+  }
+
+  func save(filename: String) -> Int32 {
+    guard let audio else {
+      return 0
+    }
+    return SherpaOnnxWriteWave(audio.pointee.samples, n, sampleRate, toCPointer(filename))
+  }
+}
+
+class SherpaOnnxOfflineSpeechDenoiserWrapper {
+  /// A pointer to the underlying counterpart in C
+  let impl: OpaquePointer!
+
+  /// Constructor taking a model config
+  init(
+    config: UnsafePointer<SherpaOnnxOfflineSpeechDenoiserConfig>!
+  ) {
+    impl = SherpaOnnxCreateOfflineSpeechDenoiser(config)
+  }
+
+  deinit {
+    if let impl {
+      SherpaOnnxDestroyOfflineSpeechDenoiser(impl)
+    }
+  }
+
+  func run(samples: [Float], sampleRate: Int) -> SherpaOnnxDenoisedAudioWrapper {
+    let audio: UnsafePointer<SherpaOnnxDenoisedAudio>? = SherpaOnnxOfflineSpeechDenoiserRun(
+      impl, samples, Int32(samples.count), Int32(sampleRate))
+
+    return SherpaOnnxDenoisedAudioWrapper(audio: audio)
+  }
+
+  var sampleRate: Int {
+    return Int(SherpaOnnxOfflineSpeechDenoiserGetSampleRate(impl))
+  }
+}
+
+func sherpaOnnxOnlineSpeechDenoiserConfig(
+  model: SherpaOnnxOfflineSpeechDenoiserModelConfig =
+    sherpaOnnxOfflineSpeechDenoiserModelConfig()
+) -> SherpaOnnxOnlineSpeechDenoiserConfig {
+  return SherpaOnnxOnlineSpeechDenoiserConfig(model: model)
+}
+
+class SherpaOnnxOnlineSpeechDenoiserWrapper {
+  let impl: OpaquePointer!
+
+  init(
+    config: UnsafePointer<SherpaOnnxOnlineSpeechDenoiserConfig>!
+  ) {
+    impl = SherpaOnnxCreateOnlineSpeechDenoiser(config)
+  }
+
+  deinit {
+    if let impl {
+      SherpaOnnxDestroyOnlineSpeechDenoiser(impl)
+    }
+  }
+
+  func run(samples: [Float], sampleRate: Int) -> SherpaOnnxDenoisedAudioWrapper {
+    let audio: UnsafePointer<SherpaOnnxDenoisedAudio>? = SherpaOnnxOnlineSpeechDenoiserRun(
+      impl, samples, Int32(samples.count), Int32(sampleRate))
+    return SherpaOnnxDenoisedAudioWrapper(audio: audio)
+  }
+
+  func flush() -> SherpaOnnxDenoisedAudioWrapper {
+    let audio: UnsafePointer<SherpaOnnxDenoisedAudio>? = SherpaOnnxOnlineSpeechDenoiserFlush(impl)
+    return SherpaOnnxDenoisedAudioWrapper(audio: audio)
+  }
+
+  func reset() {
+    SherpaOnnxOnlineSpeechDenoiserReset(impl)
+  }
+
+  var sampleRate: Int {
+    return Int(SherpaOnnxOnlineSpeechDenoiserGetSampleRate(impl))
+  }
+
+  var frameShiftInSamples: Int {
+    return Int(SherpaOnnxOnlineSpeechDenoiserGetFrameShiftInSamples(impl))
+  }
+}
+
+func getSherpaOnnxVersion() -> String {
+  return String(cString: SherpaOnnxGetVersionStr())
+}
+
+func getSherpaOnnxGitSha1() -> String {
+  return String(cString: SherpaOnnxGetGitSha1())
+}
+
+func getSherpaOnnxGitDate() -> String {
+  return String(cString: SherpaOnnxGetGitDate())
+}
+//---------------------------
+// Source separation
+//---------------------------
+
+struct AudioData {
+  private enum Storage {
+    case owned([Float])
+    case wrapped(ManagedWave)
+  }
+
+  private class ManagedWave {
+    let pointer: UnsafePointer<SherpaOnnxMultiChannelWave>
+    init(_ p: UnsafePointer<SherpaOnnxMultiChannelWave>) { self.pointer = p }
+    deinit { SherpaOnnxFreeMultiChannelWave(pointer) }
+  }
+
+  private let storage: Storage
+  let channelCount: Int
+  let samplesPerChannel: Int
+  let sampleRate: Int
+
+  init(samples: [Float], channelCount: Int, sampleRate: Int) {
+    self.storage = .owned(samples)
+    self.channelCount = channelCount
+    self.sampleRate = sampleRate
+    self.samplesPerChannel = channelCount > 0 ? samples.count / channelCount : 0
+  }
+
+  init?(filename: String) {
+    guard let ptr = SherpaOnnxReadWaveMultiChannel(filename) else { return nil }
+    self.storage = .wrapped(ManagedWave(ptr))
+    self.channelCount = Int(ptr.pointee.num_channels)
+    self.samplesPerChannel = Int(ptr.pointee.num_samples)
+    self.sampleRate = Int(ptr.pointee.sample_rate)
+  }
+
+  func withUnsafeBufferPointer<R>(_ body: (UnsafeBufferPointer<Float>) -> R) -> R {
+    switch storage {
+    case .owned(let array):
+      return array.withUnsafeBufferPointer(body)
+    case .wrapped(let managed):
+      let total = Int(managed.pointer.pointee.num_channels * managed.pointer.pointee.num_samples)
+      // Ensure we start from the first channel's pointer
+      return body(UnsafeBufferPointer(start: managed.pointer.pointee.samples[0], count: total))
+    }
+  }
+
+  @discardableResult
+  func save(to filename: String) -> Bool {
+    return withUnsafeBufferPointer { buf in
+      guard let base = buf.baseAddress else { return false }
+      // FIX: Explicitly type the array as Optional pointers to match C 'float* const*'
+      var ptrs: [UnsafePointer<Float>?] = (0..<channelCount).map { base + ($0 * samplesPerChannel) }
+
+      return SherpaOnnxWriteWaveMultiChannel(
+        &ptrs,
+        Int32(samplesPerChannel),
+        Int32(sampleRate),
+        Int32(channelCount),
+        filename
+      ) == 1
+    }
+  }
+}
+
+struct SourceSeparationConfig {
+  struct Spleeter {
+    var vocals: String
+    var accompaniment: String
+  }
+  struct Uvr { var model: String }
+
+  var spleeter: Spleeter?
+  var uvr: Uvr?
+  var numThreads: Int = 1
+  var debug: Bool = false
+  var provider: String = "cpu"
+
+  func withCConfig<R>(_ body: (UnsafePointer<SherpaOnnxOfflineSourceSeparationConfig>) -> R) -> R {
+    var cConfig = SherpaOnnxOfflineSourceSeparationConfig()
+    cConfig.model.num_threads = Int32(self.numThreads)
+    cConfig.model.debug = self.debug ? 1 : 0
+
+    var s: [String: [Int8]] = [:]
+    func b(_ k: String, _ v: String?) -> UnsafePointer<Int8>? {
+      guard let v = v else { return nil }
+      s[k] = Array(v.utf8CString)
+      return s[k]!.withUnsafeBufferPointer { $0.baseAddress }
+    }
+
+    cConfig.model.provider = b("provider", self.provider)
+    cConfig.model.spleeter.vocals = b("spleeter.vocals", self.spleeter?.vocals)
+    cConfig.model.spleeter.accompaniment = b("spleeter.accompaniment", self.spleeter?.accompaniment)
+    cConfig.model.uvr.model = b("uvr.model", self.uvr?.model)
+
+    return body(&cConfig)
+  }
+}
+
+class SourceSeparator {
+  private var engine: OpaquePointer?
+
+  init?(config: SourceSeparationConfig) {
+    self.engine = config.withCConfig { SherpaOnnxCreateOfflineSourceSeparation($0) }
+
+    if self.engine == nil { return nil }
+  }
+
+  deinit {
+    if let e = engine {
+      SherpaOnnxDestroyOfflineSourceSeparation(e)
+    }
+  }
+
+  func process(buffer: AudioData) -> [AudioData]? {
+    guard let engine = engine else { return nil }
+
+    return buffer.withUnsafeBufferPointer { flatBuf in
+      guard let base = flatBuf.baseAddress else { return nil }
+      var ptrs: [UnsafePointer<Float>?] = (0..<buffer.channelCount).map {
+        base + ($0 * buffer.samplesPerChannel)
+      }
+
+      guard
+        let raw = SherpaOnnxOfflineSourceSeparationProcess(
+          engine,
+          &ptrs,
+          Int32(buffer.channelCount),
+          Int32(buffer.samplesPerChannel),
+          Int32(buffer.sampleRate)
+        )
+      else { return nil }
+
+      let stemCount = Int(raw.pointee.num_stems)
+      let result = (0..<stemCount).map { i in
+        let stem = raw.pointee.stems[i]
+        let chs = Int(stem.num_channels)
+        let n = Int(stem.n)
+        var flat = [Float](repeating: 0, count: chs * n)
+
+        for c in 0..<chs {
+          if let src = stem.samples[c] {
+            let offset = c * n
+            flat.withUnsafeMutableBufferPointer { dest in
+              let destPtr = dest.baseAddress!.advanced(by: offset)
+              destPtr.initialize(from: src, count: n)
+            }
+          }
+        }
+        return AudioData(
+          samples: flat, channelCount: chs, sampleRate: Int(raw.pointee.sample_rate))
+      }
+
+      SherpaOnnxDestroySourceSeparationOutput(raw)
+      return result
+    }
+  }
+}

--- a/native-macos/Zerm/TextToSpeech/Providers/KokoroTTSProvider.swift
+++ b/native-macos/Zerm/TextToSpeech/Providers/KokoroTTSProvider.swift
@@ -1,28 +1,33 @@
 import Foundation
 
-/// Local, on-device neural TTS via sherpa-onnx + Kokoro-82M (Apache-2.0).
+/// Local, on-device neural TTS via sherpa-onnx + Kokoro-82M (Apache-2.0 weights).
 ///
-/// SCAFFOLD: the native sherpa-onnx library + Kokoro model manager land in issue #210
-/// (requires adding the sherpa-onnx binary dependency to the Xcode project — the one piece
-/// that can't be a pure-Swift drop-in). The provider is registered now so the rest of the
-/// Read Aloud subsystem compiles and ships with cloud providers; synthesis throws until the
-/// engine is wired up.
+/// Fully offline: no API key, no network after the one-time model download (handled by
+/// `KokoroModelManager`, mirroring `WhisperModelManager`). `voice.id` is the sherpa-onnx
+/// speaker id (sid) for the `kokoro-en-v0_19` package.
 struct KokoroTTSProvider: TTSProvider {
     let kind: TTSProviderKind = .kokoro
     let displayName = "Kokoro (on-device)"
 
+    // sid order for kokoro-en-v0_19 (0:af, 1:af_bella, 2:af_nicole, 3:af_sarah, 4:af_sky,
+    // 5:am_adam, 6:am_michael, 7:bf_emma, 8:bf_isabella, 9:bm_george, 10:bm_lewis).
     let voices: [TTSVoice] = [
-        TTSVoice(id: "af_heart", displayName: "Heart (American, warm)", provider: .kokoro),
-        TTSVoice(id: "af_bella", displayName: "Bella (American)", provider: .kokoro),
-        TTSVoice(id: "am_michael", displayName: "Michael (American)", provider: .kokoro),
-        TTSVoice(id: "bf_emma", displayName: "Emma (British)", provider: .kokoro),
-        TTSVoice(id: "bm_george", displayName: "George (British)", provider: .kokoro)
+        TTSVoice(id: "1", displayName: "Bella (American, female)", provider: .kokoro),
+        TTSVoice(id: "3", displayName: "Sarah (American, female)", provider: .kokoro),
+        TTSVoice(id: "4", displayName: "Sky (American, female)", provider: .kokoro),
+        TTSVoice(id: "5", displayName: "Adam (American, male)", provider: .kokoro),
+        TTSVoice(id: "6", displayName: "Michael (American, male)", provider: .kokoro),
+        TTSVoice(id: "7", displayName: "Emma (British, female)", provider: .kokoro),
+        TTSVoice(id: "8", displayName: "Isabella (British, female)", provider: .kokoro),
+        TTSVoice(id: "9", displayName: "George (British, male)", provider: .kokoro),
+        TTSVoice(id: "10", displayName: "Lewis (British, male)", provider: .kokoro)
     ]
 
     var requiresAPIKey: Bool { false }
 
     func synthesize(text: String, voice: TTSVoice, speed: Double, apiKey: String) async throws -> TTSAudio {
-        throw TTSError.notAvailable("On-device Kokoro voices are coming soon (issue #210). Pick a cloud provider in Read Aloud settings for now.")
+        let sid = Int(voice.id) ?? 0
+        return try await KokoroModelManager.shared.synthesize(text: text, sid: sid, speed: speed)
     }
 
     func verifyAPIKey(_ key: String) async -> (isValid: Bool, errorMessage: String?) {

--- a/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
+++ b/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
@@ -16,6 +16,8 @@ struct TextToSpeechSettingsView: View {
     /// Does not call `registerHotkey()`, so it never double-binds the global shortcut.
     @StateObject private var previewController = TTSController()
 
+    @ObservedObject private var kokoro = KokoroModelManager.shared
+
     private enum VerifyState: Equatable {
         case idle, verifying, valid, invalid(String)
     }
@@ -53,6 +55,10 @@ struct TextToSpeechSettingsView: View {
 
                 if provider.requiresAPIKey {
                     apiKeySection
+                }
+
+                if providerKind.isLocal {
+                    kokoroDownloadCard
                 }
 
                 previewSection
@@ -165,14 +171,61 @@ struct TextToSpeechSettingsView: View {
             } label: {
                 Label(isPreviewing ? "Speaking…" : "Preview voice", systemImage: "play.circle.fill")
             }
-            .disabled(isPreviewing)
-
-            if providerKind.isLocal {
-                Text("On-device Kokoro voices arrive in a later update (#210).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            .disabled(isPreviewing || (providerKind.isLocal && !kokoro.isInstalled))
             Spacer()
+        }
+    }
+
+    /// On-device model download card — the TTS mirror of the Whisper model card.
+    @ViewBuilder
+    private var kokoroDownloadCard: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: "cpu")
+                    Text(KokoroModelManager.package.displayName).font(.headline)
+                    Spacer()
+                    Text(KokoroModelManager.package.approxSize)
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                if kokoro.isInstalled {
+                    HStack {
+                        Label("Downloaded — runs fully offline", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Spacer()
+                        Button(role: .destructive) { kokoro.delete() } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                } else if kokoro.isDownloading {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ProgressView(value: kokoro.downloadProgress ?? 0)
+                        HStack {
+                            Text(kokoro.statusText ?? "Downloading…")
+                                .font(.caption).foregroundStyle(.secondary)
+                            Spacer()
+                            if let p = kokoro.downloadProgress {
+                                Text("\(Int(p * 100))%").font(.caption.monospacedDigit())
+                            }
+                            Button("Cancel") { kokoro.cancelDownload() }
+                        }
+                    }
+                } else {
+                    HStack {
+                        Text("Download once to use Kokoro offline. No API key needed.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        Button { Task { await kokoro.download() } } label: {
+                            Label("Download model", systemImage: "arrow.down.circle")
+                        }
+                    }
+                    if let status = kokoro.statusText {
+                        Text(status).font(.caption).foregroundStyle(.red)
+                    }
+                }
+            }
+            .padding(8)
         }
     }
 

--- a/native-macos/Zerm/Zerm-Bridging-Header.h
+++ b/native-macos/Zerm/Zerm-Bridging-Header.h
@@ -1,0 +1,9 @@
+// swfit-api-examples/SherpaOnnx-Bridging-Header.h
+//
+// Copyright (c)  2023  Xiaomi Corporation
+#ifndef SWIFT_API_EXAMPLES_SHERPAONNX_BRIDGING_HEADER_H_
+#define SWIFT_API_EXAMPLES_SHERPAONNX_BRIDGING_HEADER_H_
+
+#import "sherpa-onnx/c-api/c-api.h"
+
+#endif  // SWIFT_API_EXAMPLES_SHERPAONNX_BRIDGING_HEADER_H_


### PR DESCRIPTION
## On-device Read Aloud — same UX as Whisper models
Makes the local Kokoro voice real. Select **Kokoro** in Read Aloud settings → download the model once (progress bar) → it runs **fully offline**, no API key. Closes #210.

Build verified: `xcodebuild` Debug **and** `make local` → **BUILD SUCCEEDED**. Model download + extraction validated end-to-end (kokoro-en-v0_19, 305 MB → model.onnx/voices.bin/tokens.txt/espeak-ng-data).

### Native integration
- Links **sherpa-onnx.xcframework** + **onnxruntime.xcframework** (static, universal arm64+x86_64) via the same `$(HOME)/Zerm-Dependencies` pattern as whisper.xcframework
- Objective-C bridging header for the sherpa-onnx C API; `-lc++` + Accelerate added to `OTHER_LDFLAGS`
- New `make sherpa` target builds both xcframeworks (mirrors `make whisper`)

### Swift
- **`KokoroModelManager`** (mirrors `WhisperModelManager`): downloads `kokoro-en-v0_19.tar.bz2` to `Application Support/.../TTSModels`, extracts with `/usr/bin/tar`, KVO download progress, install/delete
- **`KokoroEngine`** (actor, mirrors `WhisperContext`): wraps `SherpaOnnxOfflineTts`; model loads lazily off the main thread; converts Float samples → 16-bit PCM for the shared `TTSPlayer`
- **`KokoroTTSProvider`**: real synthesis, sid → en-v0_19 speakers
- Read Aloud settings: model download/delete card with progress, mirroring the Whisper model card
- Vendors `SherpaOnnx.swift` (Apache-2.0)

### Licensing
sherpa-onnx statically links espeak-ng (**GPLv3**). Zerm is **GPL-3.0**, so this is compatible. Kokoro weights are Apache-2.0.

### Test notes
- A fresh checkout must run `make sherpa` once (builds the xcframeworks into `~/Zerm-Dependencies`), same as `make whisper`.
- Build + model-management verified; final **audio output is best confirmed by ear** — select Kokoro, Preview, listen. The en-v0_19 speaker→sid order is the documented sherpa order; tweak `KokoroTTSProvider.voices` if a name doesn't match the voice.

Part of epic #220.