### PR TITLE
Fix recurring stuck/unfocusable main window in menu-bar-only mode

### DIFF
--- a/native-macos/Zerm/WindowManager.swift
+++ b/native-macos/Zerm/WindowManager.swift
@@ -43,7 +43,19 @@ class WindowManager: NSObject {
         window.setFrameAutosaveName(Self.mainWindowAutosaveName)
         applyInitialPlacementIfNeeded(to: window)
         registerMainWindowIfNeeded(window)
-        window.orderFrontRegardless()
+
+        // Guard the recurring "stuck window" bug. In menu-bar-only mode the app runs as
+        // .accessory, where a visible main window cannot become key/active — it shows but
+        // can't take focus, so the whole UI looks frozen (can't navigate or change settings).
+        // SwiftUI's WindowGroup still instantiates the window at launch, and forcing it front
+        // here races MenuBarManager's hideMainWindow(). If we're .accessory, keep the window
+        // hidden; it is shown with .regular policy when opened from the menu bar.
+        if NSApplication.shared.activationPolicy() == .accessory {
+            logger.notice("configureWindow: app is .accessory (menu-bar-only) — keeping main window hidden to avoid an unfocusable window")
+            window.orderOut(nil)
+        } else {
+            window.orderFrontRegardless()
+        }
 
         // SwiftUI restores ITS OWN autosave frame (keyed by the full view-hierarchy
         // type string) AFTER this method returns, potentially overriding our placement.


### PR DESCRIPTION
## The recurring "stuck window" bug
Symptom: the main window is visible but the **whole UI is frozen** — can't switch sidebar screens or change any settings. (Diagnosed live: `lsappinfo` showed the app running as `UIElement`/`.accessory`, main thread idle in its run loop — i.e. not a hang, an activation issue.)

### Root cause
With `IsMenuBarOnly = true` the app runs as **`.accessory`**, where a visible main window can't become key/active — it shows but can't take focus. SwiftUI's `WindowGroup` still instantiates the window at launch, and `WindowManager.configureWindow` forced it front with `orderFrontRegardless()`, racing `MenuBarManager.hideMainWindow()`. When the race lost, the window stayed **visible but unfocusable** → looks frozen. (The Read Aloud voice still worked because synthesis doesn't need window focus — which is what made it confusing.)

### Fix
`configureWindow` now keeps the window hidden when the app is `.accessory`, instead of forcing it front. The window is shown with `.regular` policy when opened from the menu bar (the intended menu-bar-only flow via `openMainWindowAndNavigate`/`showMainWindow`), guaranteeing a visible main window is always focusable. No more stuck state regardless of how `IsMenuBarOnly` gets toggled.

Relates to the earlier menu-bar-only activation fixes (VoiceInk #576 / Zerm #26).