### PR TITLE
Read Aloud: Dashboard 'Words Read Aloud' stat + default shortcut (⌃⌥R)

### DIFF
--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -3,7 +3,8 @@ import KeyboardShortcuts
 import os
 
 extension KeyboardShortcuts.Name {
-    static let readSelectedTextAloud = Self("readSelectedTextAloud")
+    // Ships with a sensible default (⌃⌥R) so Read Aloud works out of the box; the user can rebind it.
+    static let readSelectedTextAloud = Self("readSelectedTextAloud", default: .init(.r, modifiers: [.control, .option]))
 }
 
 /// Orchestrates the Read Aloud feature: hotkey → fetch selected text → synthesize → play.
@@ -82,6 +83,7 @@ final class TTSController: ObservableObject {
             try player.play(audio) { [weak self] in
                 self?.isSpeaking = false
             }
+            TTSSettings.recordReadAloud(of: text)
         } catch is CancellationError {
             isSpeaking = false
         } catch {

--- a/native-macos/Zerm/TextToSpeech/TTSModels.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSModels.swift
@@ -75,6 +75,8 @@ enum TTSSettings {
         static let provider = "ttsProviderKind"
         static let speed = "ttsSpeed"
         static let restoreClipboard = "ttsRestoreClipboard"
+        static let wordsReadAloud = "ttsWordsReadAloud"
+        static let sessionsReadAloud = "ttsSessionsReadAloud"
         static func voice(for kind: TTSProviderKind) -> String { "ttsVoice_\(kind.rawValue)" }
     }
 
@@ -100,6 +102,18 @@ enum TTSSettings {
 
     static func setVoiceID(_ id: String, for kind: TTSProviderKind) {
         defaults.set(id, forKey: Keys.voice(for: kind))
+    }
+
+    // MARK: - Usage stats (shown on the Dashboard)
+
+    static var wordsReadAloud: Int { defaults.integer(forKey: Keys.wordsReadAloud) }
+    static var sessionsReadAloud: Int { defaults.integer(forKey: Keys.sessionsReadAloud) }
+
+    /// Records one successful Read Aloud of `text`.
+    static func recordReadAloud(of text: String) {
+        let words = text.split(whereSeparator: \.isWhitespace).count
+        defaults.set(wordsReadAloud + words, forKey: Keys.wordsReadAloud)
+        defaults.set(sessionsReadAloud + 1, forKey: Keys.sessionsReadAloud)
     }
 
     /// Resolves the selected voice for a provider, falling back to its first voice.

--- a/native-macos/Zerm/Views/Metrics/MetricsContent.swift
+++ b/native-macos/Zerm/Views/Metrics/MetricsContent.swift
@@ -12,6 +12,7 @@ struct MetricsContent: View {
     @State private var totalDuration: TimeInterval = 0
     @State private var isLoadingMetrics: Bool = true
     @State private var metricsTask: Task<Void, Never>?
+    @AppStorage(TTSSettings.Keys.wordsReadAloud) private var wordsReadAloud: Int = 0
 
     var body: some View {
         Group {
@@ -224,6 +225,14 @@ struct MetricsContent: View {
                 value: Formatters.formattedNumber(totalKeystrokesSaved),
                 detail: "fewer keystrokes",
                 color: .orange
+            )
+
+            MetricCard(
+                icon: "speaker.wave.2.fill",
+                title: "Words Read Aloud",
+                value: Formatters.formattedNumber(wordsReadAloud),
+                detail: "spoken by Read Aloud",
+                color: .blue
             )
         }
     }


### PR DESCRIPTION
Two small Read Aloud follow-ups from local testing.

### Dashboard stat
Adds a **Words Read Aloud** card to the Dashboard next to the dictation stats. `TTSSettings.recordReadAloud(of:)` increments a persisted word/session counter on each successful synthesis; the card reads it via `@AppStorage` so it updates live.

### Default shortcut
The Read Aloud shortcut shipped **unbound**, so pressing it did nothing until the user recorded one (cause of "the shortcut doesn't work"). Now `.readSelectedTextAloud` has a default of **⌃⌥R**, so it works out of the box; users can still rebind it in Read Aloud settings.

Build verified: `xcodebuild` Debug → BUILD SUCCEEDED. Part of epic #220.