### PR TITLE
Read Aloud: modifier-key trigger dropdown (Right Command, etc.) like dictation

### DIFF
--- a/native-macos/Zerm/HotkeyManager.swift
+++ b/native-macos/Zerm/HotkeyManager.swift
@@ -52,7 +52,17 @@ class HotkeyManager: ObservableObject {
             UserDefaults.standard.set(middleClickActivationDelay, forKey: "middleClickActivationDelay")
         }
     }
-    
+    /// Modifier key (or Custom) that triggers Read Aloud, mirroring the dictation hotkey dropdown.
+    @Published var readAloudHotkey: HotkeyOption {
+        didSet {
+            UserDefaults.standard.set(readAloudHotkey.rawValue, forKey: "readAloudHotkey")
+            setupHotkeyMonitoring()
+        }
+    }
+    /// Invoked when the Read Aloud trigger fires (wired to TTSController.toggle()).
+    var onReadAloudTriggered: (() -> Void)?
+    private var readAloudKeyState = false
+
     private let logger = Logger(subsystem: "com.arcusis.zerm", category: "HotkeyManager")
     private var engine: ZermEngine
     private var recorderUIManager: RecorderUIManager
@@ -163,6 +173,7 @@ class HotkeyManager: ObservableObject {
 
         self.isMiddleClickToggleEnabled = UserDefaults.standard.bool(forKey: "isMiddleClickToggleEnabled")
         self.middleClickActivationDelay = UserDefaults.standard.integer(forKey: "middleClickActivationDelay")
+        self.readAloudHotkey = HotkeyOption(rawValue: UserDefaults.standard.string(forKey: "readAloudHotkey") ?? "") ?? .none
 
         self.engine = engine
         self.recorderUIManager = recorderUIManager
@@ -228,7 +239,7 @@ class HotkeyManager: ObservableObject {
     
     private func setupModifierKeyMonitoring() {
         // Only set up if at least one hotkey is a modifier key
-        guard (selectedHotkey1.isModifierKey && selectedHotkey1 != .none) || (selectedHotkey2.isModifierKey && selectedHotkey2 != .none) else { return }
+        guard (selectedHotkey1.isModifierKey && selectedHotkey1 != .none) || (selectedHotkey2.isModifierKey && selectedHotkey2 != .none) || (readAloudHotkey.isModifierKey && readAloudHotkey != .none) else { return }
 
         globalEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             guard let self = self else { return }
@@ -316,6 +327,11 @@ class HotkeyManager: ObservableObject {
                 Task { @MainActor in await self?.handleCustomShortcutKeyUp(eventTime: eventTime, mode: self?.hotkeyMode2 ?? .toggle) }
             }
         }
+        if readAloudHotkey == .custom {
+            KeyboardShortcuts.onKeyDown(for: .readSelectedTextAloud) { [weak self] in
+                Task { @MainActor in self?.onReadAloudTriggered?() }
+            }
+        }
     }
     
     private func removeAllMonitoring() {
@@ -353,12 +369,34 @@ class HotkeyManager: ObservableObject {
         shortcutCurrentKeyState = false
         shortcutKeyPressEventTime = nil
         isShortcutHandsFreeMode = false
+        readAloudKeyState = false
     }
     
+    static func isModifierPressed(_ option: HotkeyOption, flags: NSEvent.ModifierFlags) -> Bool {
+        switch option {
+        case .rightOption, .leftOption: return flags.contains(.option)
+        case .leftControl, .rightControl: return flags.contains(.control)
+        case .fn: return flags.contains(.function)
+        case .rightCommand: return flags.contains(.command)
+        case .rightShift: return flags.contains(.shift)
+        case .custom, .none: return false
+        }
+    }
+
     private func handleModifierKeyEvent(_ event: NSEvent) async {
         let keycode = event.keyCode
         let flags = event.modifierFlags
         let eventTime = event.timestamp
+
+        // Read Aloud trigger — independent of dictation. Simple tap-to-toggle on key down.
+        if readAloudHotkey.isModifierKey, readAloudHotkey != .none, readAloudHotkey.keyCode == keycode {
+            let pressed = Self.isModifierPressed(readAloudHotkey, flags: flags)
+            if pressed != readAloudKeyState {
+                readAloudKeyState = pressed
+                if pressed { onReadAloudTriggered?() }
+            }
+            return
+        }
 
         let activeMode: HotkeyMode
         let activeHotkey: HotkeyOption?

--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -20,13 +20,6 @@ final class TTSController: ObservableObject {
 
     init() {}
 
-    /// Registers the global Read Aloud shortcut. Call exactly once, from app startup.
-    func registerHotkey() {
-        KeyboardShortcuts.onKeyDown(for: .readSelectedTextAloud) { [weak self] in
-            self?.toggle()
-        }
-    }
-
     /// Hotkey action: start reading the selection, or stop if already speaking.
     func toggle() {
         guard TTSSettings.isEnabled else { return }

--- a/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
+++ b/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
@@ -17,6 +17,7 @@ struct TextToSpeechSettingsView: View {
     @StateObject private var previewController = TTSController()
 
     @ObservedObject private var kokoro = KokoroModelManager.shared
+    @EnvironmentObject private var hotkeyManager: HotkeyManager
 
     private enum VerifyState: Equatable {
         case idle, verifying, valid, invalid(String)
@@ -82,11 +83,40 @@ struct TextToSpeechSettingsView: View {
     }
 
     private var shortcutRow: some View {
-        HStack {
-            Label("Shortcut", systemImage: "command")
-            Spacer()
-            KeyboardShortcuts.Recorder(for: .readSelectedTextAloud)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Trigger key", systemImage: "command")
+                Spacer()
+                Picker("", selection: $hotkeyManager.readAloudHotkey) {
+                    ForEach(HotkeyManager.HotkeyOption.allCases, id: \.self) { option in
+                        Text(option.displayName).tag(option)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 240)
+            }
+
+            if hotkeyManager.readAloudHotkey == .custom {
+                HStack {
+                    Text("Custom shortcut").foregroundStyle(.secondary)
+                    Spacer()
+                    KeyboardShortcuts.Recorder(for: .readSelectedTextAloud)
+                }
+            }
+
+            if readAloudHotkeyConflictsWithDictation {
+                Label("This key is also your dictation hotkey — pick a different one to avoid both firing.",
+                      systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
         }
+    }
+
+    private var readAloudHotkeyConflictsWithDictation: Bool {
+        let key = hotkeyManager.readAloudHotkey
+        guard key != .none, key != .custom else { return false }
+        return key == hotkeyManager.selectedHotkey1 || key == hotkeyManager.selectedHotkey2
     }
 
     private var providerRow: some View {

--- a/native-macos/Zerm/Zerm.swift
+++ b/native-macos/Zerm/Zerm.swift
@@ -151,8 +151,10 @@ struct ZermApp: App {
         menuBarManager.configure(modelContainer: container, engine: engine)
 
         // Read Aloud (text-to-speech) — mirror of the dictation flow.
+        // HotkeyManager owns the trigger (modifier-key dropdown or custom shortcut),
+        // consistent with dictation; it calls back into the controller.
         let ttsController = TTSController()
-        ttsController.registerHotkey()
+        hotkeyManager.onReadAloudTriggered = { [weak ttsController] in ttsController?.toggle() }
         _ttsController = StateObject(wrappedValue: ttsController)
 
         let activeWindowService = ActiveWindowService.shared


### PR DESCRIPTION
## Why
The `KeyboardShortcuts` 'Record Shortcut' widget can't bind a **bare modifier** (e.g. Right Command) — it requires key+modifier — so users couldn't set the trigger they wanted, and it felt like the recorder was 'not working'.

## What
Give Read Aloud the **same trigger dropdown as dictation** (`HotkeyOption`: None / Right Command / Right Option / Right/Left Control / Right Shift / Fn / Custom), wired into `HotkeyManager`'s existing `flagsChanged` monitor that already powers bare-modifier dictation triggers.

- `HotkeyManager`: `readAloudHotkey` + `onReadAloudTriggered`; modifier detected in `handleModifierKeyEvent` (simple tap-to-toggle), `.custom` via the recorder
- `Zerm.swift` wires `onReadAloudTriggered -> ttsController.toggle()`; `TTSController` no longer self-registers
- Read Aloud settings: trigger-key dropdown (+ recorder when Custom) and a conflict warning if it matches the dictation hotkey

Build verified: `xcodebuild` Debug → BUILD SUCCEEDED. Part of epic #220.