### PR TITLE
Read Aloud: reuse the recorder widget + mutual exclusion with dictation

### DIFF
--- a/native-macos/Zerm/HotkeyManager.swift
+++ b/native-macos/Zerm/HotkeyManager.swift
@@ -71,7 +71,7 @@ class HotkeyManager: ObservableObject {
 
     // MARK: - Helper Properties
     private var canProcessHotkeyAction: Bool {
-        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy
+        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy && engine.recordingState != .speaking
     }
     
     // NSEvent monitoring for modifier keys

--- a/native-macos/Zerm/MiniRecorderShortcutManager.swift
+++ b/native-macos/Zerm/MiniRecorderShortcutManager.swift
@@ -90,7 +90,7 @@ class MiniRecorderShortcutManager: ObservableObject {
                 if let firstTime = self.escFirstPressTime,
                    now.timeIntervalSince(firstTime) <= self.escSecondPressThreshold {
                     self.escFirstPressTime = nil
-                    await self.recorderUIManager.cancelRecording()
+                    await self.recorderUIManager.cancelActiveOperation()
                 } else {
                     self.escFirstPressTime = now
                     SoundManager.shared.playEscSound()
@@ -127,7 +127,7 @@ class MiniRecorderShortcutManager: ObservableObject {
                       await self.recorderUIManager.isMiniRecorderVisible,
                       KeyboardShortcuts.getShortcut(for: .cancelRecorder) != nil else { return }
 
-                await self.recorderUIManager.cancelRecording()
+                await self.recorderUIManager.cancelActiveOperation()
             }
         }
     }

--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -18,7 +18,13 @@ final class TTSController: ObservableObject {
     private var task: Task<Void, Never>?
     private let logger = Logger(subsystem: "com.arcusis.zerm", category: "TTSController")
 
-    init() {}
+    weak var engine: ZermEngine?
+    weak var recorderUIManager: RecorderUIManager?
+
+    init(engine: ZermEngine? = nil, recorderUIManager: RecorderUIManager? = nil) {
+        self.engine = engine
+        self.recorderUIManager = recorderUIManager
+    }
 
     /// Hotkey action: start reading the selection, or stop if already speaking.
     func toggle() {
@@ -35,6 +41,7 @@ final class TTSController: ObservableObject {
         task = nil
         player.stop()
         isSpeaking = false
+        recorderUIManager?.endSpeaking()
     }
 
     /// Reads whatever text is currently selected system-wide.
@@ -50,6 +57,13 @@ final class TTSController: ObservableObject {
 
     /// Synthesizes and plays arbitrary text using the configured provider/voice.
     func speak(_ text: String) async {
+        // Mutual exclusion: never run Read Aloud while dictation owns the recorder widget.
+        if let rm = recorderUIManager, !rm.canStartSpeaking {
+            notify("Finish or cancel dictation before using Read Aloud")
+            SoundManager.shared.playEscSound()
+            return
+        }
+
         guard let provider = TTSProviderRegistry.provider(for: TTSSettings.providerKind) else {
             notify("No speech provider selected")
             return
@@ -70,17 +84,21 @@ final class TTSController: ObservableObject {
         }
 
         isSpeaking = true
+        recorderUIManager?.beginSpeaking()
         do {
             let audio = try await provider.synthesize(text: text, voice: voice, speed: TTSSettings.speed, apiKey: apiKey)
-            if Task.isCancelled { isSpeaking = false; return }
+            if Task.isCancelled { isSpeaking = false; recorderUIManager?.endSpeaking(); return }
             try player.play(audio) { [weak self] in
                 self?.isSpeaking = false
+                self?.recorderUIManager?.endSpeaking()
             }
             TTSSettings.recordReadAloud(of: text)
         } catch is CancellationError {
             isSpeaking = false
+            recorderUIManager?.endSpeaking()
         } catch {
             isSpeaking = false
+            recorderUIManager?.endSpeaking()
             logger.error("Read Aloud failed: \(error.localizedDescription, privacy: .public)")
             notify("Read Aloud failed: \(error.localizedDescription)")
         }

--- a/native-macos/Zerm/Transcription/Engine/RecorderUIManager.swift
+++ b/native-macos/Zerm/Transcription/Engine/RecorderUIManager.swift
@@ -52,6 +52,42 @@ class RecorderUIManager: ObservableObject {
         setupNotifications()
     }
 
+    // MARK: - Read Aloud (TTS) widget
+
+    /// Stops Read Aloud playback. Set by the app to TTSController.stop().
+    var onCancelSpeaking: (() -> Void)?
+
+    /// Whether Read Aloud may start — only when nothing else is using the recorder.
+    var canStartSpeaking: Bool {
+        guard let engine = engine else { return true }
+        return engine.recordingState == .idle && !isMiniRecorderVisible
+    }
+
+    /// Shows the recorder widget in "Speaking" mode (no microphone/recording).
+    func beginSpeaking() {
+        guard let engine = engine else { return }
+        engine.recordingState = .speaking
+        isMiniRecorderVisible = true
+    }
+
+    /// Hides the widget after Read Aloud finishes or is cancelled.
+    func endSpeaking() {
+        guard let engine = engine else { return }
+        if engine.recordingState == .speaking {
+            engine.recordingState = .idle
+        }
+        isMiniRecorderVisible = false
+    }
+
+    /// Cancels whatever the recorder is currently doing — Read Aloud or a recording.
+    func cancelActiveOperation() async {
+        if engine?.recordingState == .speaking {
+            onCancelSpeaking?()
+        } else {
+            await cancelRecording()
+        }
+    }
+
     // MARK: - Recorder Panel Management
 
     func showRecorderPanel() {
@@ -85,6 +121,12 @@ class RecorderUIManager: ObservableObject {
         guard let engine = engine else { return }
         logger.notice("toggleMiniRecorder called – visible=\(self.isMiniRecorderVisible, privacy: .public), state=\(String(describing: engine.recordingState), privacy: .public)")
 
+        // If Read Aloud is using the widget, this gesture stops it (don't start a recording).
+        if engine.recordingState == .speaking {
+            onCancelSpeaking?()
+            return
+        }
+
         if isMiniRecorderVisible {
             if engine.recordingState == .recording {
                 logger.notice("toggleMiniRecorder: stopping recording (was recording)")
@@ -106,6 +148,11 @@ class RecorderUIManager: ObservableObject {
     func dismissMiniRecorder() async {
         guard let engine = engine, let recorder = recorder else { return }
         logger.notice("dismissMiniRecorder called – state=\(String(describing: engine.recordingState), privacy: .public)")
+
+        if engine.recordingState == .speaking {
+            onCancelSpeaking?()
+            return
+        }
 
         if engine.recordingState == .busy {
             logger.notice("dismissMiniRecorder: early return, state is busy")

--- a/native-macos/Zerm/Transcription/Engine/RecordingState.swift
+++ b/native-macos/Zerm/Transcription/Engine/RecordingState.swift
@@ -6,5 +6,6 @@ enum RecordingState: Equatable {
     case recording
     case transcribing
     case enhancing
+    case speaking   // Read Aloud (TTS) is playing — reuses the recorder widget
     case busy
 }

--- a/native-macos/Zerm/Views/Recorder/AudioVisualizerView.swift
+++ b/native-macos/Zerm/Views/Recorder/AudioVisualizerView.swift
@@ -70,6 +70,7 @@ struct ProcessingStatusDisplay: View {
     enum Mode {
         case transcribing
         case enhancing
+        case speaking
     }
 
     let mode: Mode
@@ -79,6 +80,7 @@ struct ProcessingStatusDisplay: View {
         switch mode {
         case .transcribing: return "Transcribing"
         case .enhancing:    return "Enhancing"
+        case .speaking:     return "Speaking"
         }
     }
 
@@ -86,6 +88,7 @@ struct ProcessingStatusDisplay: View {
         switch mode {
         case .transcribing: return 0.18
         case .enhancing:    return 0.22
+        case .speaking:     return 0.20
         }
     }
 

--- a/native-macos/Zerm/Views/Recorder/NotchRecorderView.swift
+++ b/native-macos/Zerm/Views/Recorder/NotchRecorderView.swift
@@ -22,7 +22,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
         case .recording:
             let shouldShowLive = showLiveTextPreview && !stateProvider.partialTranscript.isEmpty
             return shouldShowLive ? .liveText : .active
-        case .transcribing, .enhancing:
+        case .transcribing, .enhancing, .speaking:
             return .active
         default:
             return .collapsed

--- a/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
+++ b/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
@@ -314,7 +314,9 @@ struct RecorderStatusDisplay: View {
 
     var body: some View {
         Group {
-            if currentState == .enhancing {
+            if currentState == .speaking {
+                ProcessingStatusDisplay(mode: .speaking, color: .white).transition(.opacity)
+            } else if currentState == .enhancing {
                 ProcessingStatusDisplay(mode: .enhancing, color: .white).transition(.opacity)
             } else if currentState == .transcribing {
                 ProcessingStatusDisplay(mode: .transcribing, color: .white).transition(.opacity)

--- a/native-macos/Zerm/Zerm.swift
+++ b/native-macos/Zerm/Zerm.swift
@@ -153,8 +153,9 @@ struct ZermApp: App {
         // Read Aloud (text-to-speech) — mirror of the dictation flow.
         // HotkeyManager owns the trigger (modifier-key dropdown or custom shortcut),
         // consistent with dictation; it calls back into the controller.
-        let ttsController = TTSController()
+        let ttsController = TTSController(engine: engine, recorderUIManager: recorderUIManager)
         hotkeyManager.onReadAloudTriggered = { [weak ttsController] in ttsController?.toggle() }
+        recorderUIManager.onCancelSpeaking = { [weak ttsController] in ttsController?.stop() }
         _ttsController = StateObject(wrappedValue: ttsController)
 
         let activeWindowService = ActiveWindowService.shared


### PR DESCRIPTION
## Read Aloud is now fully integrated with the recorder widget
Triggering Read Aloud shows the **same animated mini/notch widget** as dictation (new **"Speaking"** state), driven by the same `RecordingState` machine — and the two can never run simultaneously or crash.

- `RecordingState.speaking`; `ProcessingStatusDisplay` renders "Speaking"; notch expands for it
- `RecorderUIManager`: `beginSpeaking`/`endSpeaking` (show/hide without recording), `canStartSpeaking` gate, `cancelActiveOperation`, and `.speaking` routing in `toggleMiniRecorder`/`dismissMiniRecorder` → `onCancelSpeaking`
- `TTSController`: shows the widget while synthesizing/playing, hides on finish/cancel/error; refuses to start while dictation owns the recorder
- `HotkeyManager`: `.speaking` blocks dictation from starting during Read Aloud
- **Double-Escape** cancels whichever is active (TTS or recording)

**Mutual exclusion** is enforced through the single `engine.recordingState` source of truth, so no collisions and no crashes. Build verified: `xcodebuild` Debug → BUILD SUCCEEDED. Part of epic #220.