### PR TITLE
Read Aloud: live audio-bar visualizer (true mirror of dictation)

### DIFF
--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -24,6 +24,14 @@ final class TTSController: ObservableObject {
     init(engine: ZermEngine? = nil, recorderUIManager: RecorderUIManager? = nil) {
         self.engine = engine
         self.recorderUIManager = recorderUIManager
+
+        // Feed the TTS output level into the recorder's meter so the widget shows live
+        // audio bars while speaking — the same visualizer dictation uses. Capture the
+        // recorder directly (a plain class) to avoid main-actor isolation in the tap.
+        let recorderRef = engine?.recorder
+        player.onLevel = { level in
+            recorderRef?.audioMeter = AudioMeter(averagePower: level, peakPower: level)
+        }
     }
 
     /// Hotkey action: start reading the selection, or stop if already speaking.

--- a/native-macos/Zerm/TextToSpeech/TTSPlayer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSPlayer.swift
@@ -11,6 +11,10 @@ final class TTSPlayer {
     private var attached = false
     private var currentSampleRate: Double = 0
     private var currentChannels: AVAudioChannelCount = 0
+    private var tapInstalled = false
+
+    /// Output level (0...1) during playback, so the recorder widget can show live bars.
+    var onLevel: ((Double) -> Void)?
 
     init() {
         engine.attach(playerNode)
@@ -61,7 +65,10 @@ final class TTSPlayer {
             try engine.start()
         }
 
-        playerNode.scheduleBuffer(buffer, at: nil, options: []) {
+        installMeteringTap()
+
+        playerNode.scheduleBuffer(buffer, at: nil, options: []) { [weak self] in
+            self?.teardownMeteringTap()
             DispatchQueue.main.async { onFinished() }
         }
         playerNode.play()
@@ -71,7 +78,40 @@ final class TTSPlayer {
         if playerNode.isPlaying {
             playerNode.stop()
         }
+        teardownMeteringTap()
     }
 
     var isPlaying: Bool { playerNode.isPlaying }
+
+    // MARK: - Output level metering (drives the widget's audio bars)
+
+    private func installMeteringTap() {
+        guard !tapInstalled else { return }
+        engine.mainMixerNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
+            let level = TTSPlayer.rms(buffer)
+            DispatchQueue.main.async { self?.onLevel?(level) }
+        }
+        tapInstalled = true
+    }
+
+    private func teardownMeteringTap() {
+        guard tapInstalled else { return }
+        engine.mainMixerNode.removeTap(onBus: 0)
+        tapInstalled = false
+        DispatchQueue.main.async { [weak self] in self?.onLevel?(0) }
+    }
+
+    private static func rms(_ buffer: AVAudioPCMBuffer) -> Double {
+        guard let data = buffer.floatChannelData else { return 0 }
+        let frames = Int(buffer.frameLength)
+        guard frames > 0 else { return 0 }
+        let ch0 = data[0]
+        var sum: Float = 0
+        for i in 0..<frames {
+            let s = ch0[i]
+            sum += s * s
+        }
+        let rms = (sum / Float(frames)).squareRoot()
+        return Double(min(1.0, rms * 3.5)) // gain for visual punch
+    }
 }

--- a/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
+++ b/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
@@ -315,7 +315,11 @@ struct RecorderStatusDisplay: View {
     var body: some View {
         Group {
             if currentState == .speaking {
-                ProcessingStatusDisplay(mode: .speaking, color: .white).transition(.opacity)
+                // Read Aloud shows the same animated bars as recording, driven by the TTS
+                // output level (see TTSPlayer metering tap → recorder.audioMeter).
+                AudioVisualizer(audioMeter: audioMeter, color: .white, isActive: true)
+                    .scaleEffect(y: menuBarHeight != nil ? min(1.0, (menuBarHeight! - 8) / 25) : 1.0, anchor: .center)
+                    .transition(.opacity)
             } else if currentState == .enhancing {
                 ProcessingStatusDisplay(mode: .enhancing, color: .white).transition(.opacity)
             } else if currentState == .transcribing {


### PR DESCRIPTION
Read Aloud's widget now shows the **same animated audio bars** as dictation, driven by the **real TTS output level** (was a 'Speaking' progress-dots placeholder).

- `TTSPlayer` taps the engine mixer during playback → RMS level → `onLevel`
- `TTSController` feeds it into `recorder.audioMeter`
- `.speaking` renders `AudioVisualizer(isActive: true)`, identical to recording

Build verified. Part of epic #220.