### PR TITLE
Read Aloud: instant feel — loading state + Kokoro pre-warm

### DIFF
--- a/native-macos/Zerm/HotkeyManager.swift
+++ b/native-macos/Zerm/HotkeyManager.swift
@@ -71,7 +71,7 @@ class HotkeyManager: ObservableObject {
 
     // MARK: - Helper Properties
     private var canProcessHotkeyAction: Bool {
-        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy && engine.recordingState != .speaking
+        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy && engine.recordingState != .speaking && engine.recordingState != .preparingSpeech
     }
     
     // NSEvent monitoring for modifier keys

--- a/native-macos/Zerm/TextToSpeech/Kokoro/KokoroEngine.swift
+++ b/native-macos/Zerm/TextToSpeech/Kokoro/KokoroEngine.swift
@@ -33,6 +33,11 @@ actor KokoroEngine {
         tts = wrapper
     }
 
+    /// Loads the model ahead of time so the first `generate` is instant.
+    func warmUp() throws {
+        try ensureLoaded()
+    }
+
     func generate(text: String, sid: Int, speed: Float) throws -> (samples: [Float], sampleRate: Int) {
         try ensureLoaded()
         guard let tts else { throw TTSError.notAvailable("Kokoro engine unavailable.") }

--- a/native-macos/Zerm/TextToSpeech/Kokoro/KokoroModelManager.swift
+++ b/native-macos/Zerm/TextToSpeech/Kokoro/KokoroModelManager.swift
@@ -172,6 +172,14 @@ final class KokoroModelManager: ObservableObject {
         return TTSAudio(pcm: Self.floatToInt16PCM(samples), sampleRate: Double(sampleRate), channels: 1)
     }
 
+    /// Pre-loads the model in the background when Kokoro is the selected provider, so the
+    /// first read-aloud is instant instead of a cold ~330 MB load.
+    func prewarmIfNeeded() async {
+        guard isInstalled, TTSSettings.providerKind == .kokoro else { return }
+        let engine = ensureEngine()
+        try? await engine.warmUp()
+    }
+
     private func ensureEngine() -> KokoroEngine {
         if let engine { return engine }
         let cfg = modelConfig

--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -96,6 +96,7 @@ final class TTSController: ObservableObject {
         do {
             let audio = try await provider.synthesize(text: text, voice: voice, speed: TTSSettings.speed, apiKey: apiKey)
             if Task.isCancelled { isSpeaking = false; recorderUIManager?.endSpeaking(); return }
+            recorderUIManager?.markSpeechPlaying()   // "Preparing…" → live audio bars
             try player.play(audio) { [weak self] in
                 self?.isSpeaking = false
                 self?.recorderUIManager?.endSpeaking()

--- a/native-macos/Zerm/Transcription/Engine/RecorderUIManager.swift
+++ b/native-macos/Zerm/Transcription/Engine/RecorderUIManager.swift
@@ -57,23 +57,36 @@ class RecorderUIManager: ObservableObject {
     /// Stops Read Aloud playback. Set by the app to TTSController.stop().
     var onCancelSpeaking: (() -> Void)?
 
+    /// True while Read Aloud owns the widget (synthesizing or playing).
+    var isReadAloudActive: Bool {
+        engine?.recordingState == .speaking || engine?.recordingState == .preparingSpeech
+    }
+
     /// Whether Read Aloud may start — only when nothing else is using the recorder.
     var canStartSpeaking: Bool {
         guard let engine = engine else { return true }
         return engine.recordingState == .idle && !isMiniRecorderVisible
     }
 
-    /// Shows the recorder widget in "Speaking" mode (no microphone/recording).
+    /// Shows the recorder widget in the "Preparing…" loading state (no microphone/recording).
     func beginSpeaking() {
         guard let engine = engine else { return }
-        engine.recordingState = .speaking
+        engine.recordingState = .preparingSpeech
         isMiniRecorderVisible = true
+    }
+
+    /// Switches the widget from "Preparing…" to the live audio bars once playback starts.
+    func markSpeechPlaying() {
+        guard let engine = engine else { return }
+        if engine.recordingState == .preparingSpeech {
+            engine.recordingState = .speaking
+        }
     }
 
     /// Hides the widget after Read Aloud finishes or is cancelled.
     func endSpeaking() {
         guard let engine = engine else { return }
-        if engine.recordingState == .speaking {
+        if isReadAloudActive {
             engine.recordingState = .idle
         }
         isMiniRecorderVisible = false
@@ -81,7 +94,7 @@ class RecorderUIManager: ObservableObject {
 
     /// Cancels whatever the recorder is currently doing — Read Aloud or a recording.
     func cancelActiveOperation() async {
-        if engine?.recordingState == .speaking {
+        if isReadAloudActive {
             onCancelSpeaking?()
         } else {
             await cancelRecording()
@@ -122,7 +135,7 @@ class RecorderUIManager: ObservableObject {
         logger.notice("toggleMiniRecorder called – visible=\(self.isMiniRecorderVisible, privacy: .public), state=\(String(describing: engine.recordingState), privacy: .public)")
 
         // If Read Aloud is using the widget, this gesture stops it (don't start a recording).
-        if engine.recordingState == .speaking {
+        if isReadAloudActive {
             onCancelSpeaking?()
             return
         }
@@ -149,7 +162,7 @@ class RecorderUIManager: ObservableObject {
         guard let engine = engine, let recorder = recorder else { return }
         logger.notice("dismissMiniRecorder called – state=\(String(describing: engine.recordingState), privacy: .public)")
 
-        if engine.recordingState == .speaking {
+        if isReadAloudActive {
             onCancelSpeaking?()
             return
         }

--- a/native-macos/Zerm/Transcription/Engine/RecordingState.swift
+++ b/native-macos/Zerm/Transcription/Engine/RecordingState.swift
@@ -6,6 +6,7 @@ enum RecordingState: Equatable {
     case recording
     case transcribing
     case enhancing
-    case speaking   // Read Aloud (TTS) is playing — reuses the recorder widget
+    case preparingSpeech   // Read Aloud is synthesizing — widget shows a loading indicator
+    case speaking          // Read Aloud audio is playing — animated bars
     case busy
 }

--- a/native-macos/Zerm/Views/Recorder/AudioVisualizerView.swift
+++ b/native-macos/Zerm/Views/Recorder/AudioVisualizerView.swift
@@ -70,7 +70,7 @@ struct ProcessingStatusDisplay: View {
     enum Mode {
         case transcribing
         case enhancing
-        case speaking
+        case preparing
     }
 
     let mode: Mode
@@ -80,7 +80,7 @@ struct ProcessingStatusDisplay: View {
         switch mode {
         case .transcribing: return "Transcribing"
         case .enhancing:    return "Enhancing"
-        case .speaking:     return "Speaking"
+        case .preparing:    return "Preparing…"
         }
     }
 
@@ -88,7 +88,7 @@ struct ProcessingStatusDisplay: View {
         switch mode {
         case .transcribing: return 0.18
         case .enhancing:    return 0.22
-        case .speaking:     return 0.20
+        case .preparing:    return 0.14
         }
     }
 

--- a/native-macos/Zerm/Views/Recorder/NotchRecorderView.swift
+++ b/native-macos/Zerm/Views/Recorder/NotchRecorderView.swift
@@ -22,7 +22,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
         case .recording:
             let shouldShowLive = showLiveTextPreview && !stateProvider.partialTranscript.isEmpty
             return shouldShowLive ? .liveText : .active
-        case .transcribing, .enhancing, .speaking:
+        case .transcribing, .enhancing, .speaking, .preparingSpeech:
             return .active
         default:
             return .collapsed

--- a/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
+++ b/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
@@ -314,7 +314,10 @@ struct RecorderStatusDisplay: View {
 
     var body: some View {
         Group {
-            if currentState == .speaking {
+            if currentState == .preparingSpeech {
+                // Read Aloud is synthesizing — show a loading indicator until audio starts.
+                ProcessingStatusDisplay(mode: .preparing, color: .white).transition(.opacity)
+            } else if currentState == .speaking {
                 // Read Aloud shows the same animated bars as recording, driven by the TTS
                 // output level (see TTSPlayer metering tap → recorder.audioMeter).
                 AudioVisualizer(audioMeter: audioMeter, color: .white, isActive: true)

--- a/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
+++ b/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
@@ -273,6 +273,8 @@ struct TextToSpeechSettingsView: View {
             apiKey = ""
         }
         verifyState = .idle
+        // Warm up the on-device model when Kokoro is selected so the first read is instant.
+        Task { await kokoro.prewarmIfNeeded() }
     }
 
     private func saveAndVerify() async {

--- a/native-macos/Zerm/Zerm.swift
+++ b/native-macos/Zerm/Zerm.swift
@@ -176,6 +176,9 @@ struct ZermApp: App {
             await recorderUIManager.resetOnLaunch()
         }
 
+        // Pre-warm the on-device Read Aloud model so the first read is instant.
+        Task { await KokoroModelManager.shared.prewarmIfNeeded() }
+
         AppShortcuts.updateAppShortcutParameters()
 
         // Start cleanup service for the app's lifetime, not tied to window lifecycle


### PR DESCRIPTION
Makes Read Aloud feel instantaneous.

- **Loading state:** new `RecordingState.preparingSpeech` — the widget shows a **'Preparing…'** indicator the instant you trigger, then snaps to the live audio bars when playback starts.
- **Pre-warm:** the on-device Kokoro model loads in the background when it's the selected provider (app launch + on selection in settings), so the first read is instant instead of a cold ~330 MB load.
- Threads `preparingSpeech` through mutual exclusion, all cancel paths, and the notch active state.

Build verified. Part of epic #220. (Next lever for cloud providers: streaming playback — start audio on the first chunk.)