### PR TITLE
Read Aloud: fix stop-playback deadlock + chunked streaming for speed

### DIFF
--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -91,26 +91,59 @@ final class TTSController: ObservableObject {
             return
         }
 
+        let speed = TTSSettings.speed
+        let chunks = Self.splitIntoChunks(text)
+
         isSpeaking = true
         recorderUIManager?.beginSpeaking()
+        player.startStreaming { [weak self] in
+            self?.isSpeaking = false
+            self?.recorderUIManager?.endSpeaking()
+        }
+
+        var startedPlaying = false
         do {
-            let audio = try await provider.synthesize(text: text, voice: voice, speed: TTSSettings.speed, apiKey: apiKey)
-            if Task.isCancelled { isSpeaking = false; recorderUIManager?.endSpeaking(); return }
-            recorderUIManager?.markSpeechPlaying()   // "Preparing…" → live audio bars
-            try player.play(audio) { [weak self] in
-                self?.isSpeaking = false
-                self?.recorderUIManager?.endSpeaking()
+            for chunk in chunks {
+                try Task.checkCancellation()
+                let audio = try await provider.synthesize(text: chunk, voice: voice, speed: speed, apiKey: apiKey)
+                try Task.checkCancellation()
+                try player.enqueue(audio)
+                if !startedPlaying {
+                    startedPlaying = true
+                    recorderUIManager?.markSpeechPlaying()   // first chunk → live audio bars
+                }
             }
+            player.finishEnqueueing()
             TTSSettings.recordReadAloud(of: text)
         } catch is CancellationError {
-            isSpeaking = false
-            recorderUIManager?.endSpeaking()
+            // stop() already cleaned up the widget + player.
         } catch {
+            player.stop()
             isSpeaking = false
             recorderUIManager?.endSpeaking()
             logger.error("Read Aloud failed: \(error.localizedDescription, privacy: .public)")
             notify("Read Aloud failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Splits text into sentence-based chunks. The first chunk is a single sentence (so audio
+    /// starts fast); later chunks accumulate to ~220 chars to limit per-chunk overhead.
+    private static func splitIntoChunks(_ text: String) -> [String] {
+        var chunks: [String] = []
+        var current = ""
+        text.enumerateSubstrings(in: text.startIndex..., options: .bySentences) { sub, _, _, _ in
+            guard let sub, !sub.isEmpty else { return }
+            current += sub
+            let threshold = chunks.isEmpty ? 1 : 220
+            if current.count >= threshold {
+                chunks.append(current)
+                current = ""
+            }
+        }
+        if !current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            chunks.append(current)
+        }
+        return chunks.isEmpty ? [text] : chunks
     }
 
     private func notify(_ message: String) {

--- a/native-macos/Zerm/TextToSpeech/TTSPlayer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSPlayer.swift
@@ -3,29 +3,83 @@ import AVFoundation
 
 /// Plays raw PCM produced by any `TTSProvider` through a single `AVAudioEngine` pipeline.
 ///
-/// v1 plays a fully-synthesized buffer (read-aloud is batch by nature). The engine
-/// keeps a player node attached and reconnects when the sample rate changes.
+/// Supports streaming: chunks are enqueued as they are synthesized and play back-to-back,
+/// so Read Aloud starts speaking the first sentence while the rest is still synthesizing.
 final class TTSPlayer {
     private let engine = AVAudioEngine()
     private let playerNode = AVAudioPlayerNode()
-    private var attached = false
     private var currentSampleRate: Double = 0
     private var currentChannels: AVAudioChannelCount = 0
-    private var tapInstalled = false
+    private var meteringTapInstalled = false
+
+    private var pendingBuffers = 0
+    private var doneEnqueueing = false
+    private var onPlaybackFinished: (() -> Void)?
 
     /// Output level (0...1) during playback, so the recorder widget can show live bars.
     var onLevel: ((Double) -> Void)?
 
     init() {
         engine.attach(playerNode)
-        attached = true
     }
 
-    /// Plays `audio`, calling `onFinished` on the main queue when playback completes
-    /// (not called if interrupted by `stop()` or a new `play`).
-    func play(_ audio: TTSAudio, onFinished: @escaping () -> Void) throws {
+    /// Begins a new streaming session. `onFinished` fires (on the main queue) once every
+    /// enqueued chunk has finished playing and `finishEnqueueing()` has been called.
+    func startStreaming(onFinished: @escaping () -> Void) {
         stop()
+        pendingBuffers = 0
+        doneEnqueueing = false
+        onPlaybackFinished = onFinished
+    }
 
+    /// Schedules one synthesized chunk; starts playback on the first chunk.
+    func enqueue(_ audio: TTSAudio) throws {
+        guard let buffer = try makeBuffer(audio) else { throw TTSError.emptyAudio }
+
+        if !engine.isRunning { try engine.start() }
+        installMeteringTapIfNeeded()
+
+        pendingBuffers += 1
+        playerNode.scheduleBuffer(buffer, at: nil, options: []) { [weak self] in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.pendingBuffers -= 1
+                self.checkFinished()
+            }
+        }
+        if !playerNode.isPlaying { playerNode.play() }
+    }
+
+    /// Signals no more chunks are coming; completion fires once the queue drains.
+    func finishEnqueueing() {
+        doneEnqueueing = true
+        checkFinished()
+    }
+
+    func stop() {
+        onPlaybackFinished = nil
+        pendingBuffers = 0
+        doneEnqueueing = false
+        if playerNode.isPlaying {
+            playerNode.stop()
+        }
+        emitSilence()
+    }
+
+    var isPlaying: Bool { playerNode.isPlaying }
+
+    // MARK: - Private
+
+    private func checkFinished() {
+        guard doneEnqueueing, pendingBuffers <= 0 else { return }
+        let callback = onPlaybackFinished
+        onPlaybackFinished = nil
+        emitSilence()
+        callback?()
+    }
+
+    /// Builds a float PCM buffer from 16-bit LE PCM, (re)connecting the node if the format changed.
+    private func makeBuffer(_ audio: TTSAudio) throws -> AVAudioPCMBuffer? {
         let channels = AVAudioChannelCount(max(1, audio.channels))
         guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
                                          sampleRate: audio.sampleRate,
@@ -38,7 +92,7 @@ final class TTSPlayer {
         let frameCount = audio.pcm.count / (bytesPerSample * Int(channels))
         guard frameCount > 0,
               let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount)) else {
-            throw TTSError.emptyAudio
+            return nil
         }
         buffer.frameLength = AVAudioFrameCount(frameCount)
 
@@ -60,44 +114,24 @@ final class TTSPlayer {
             currentSampleRate = audio.sampleRate
             currentChannels = channels
         }
-
-        if !engine.isRunning {
-            try engine.start()
-        }
-
-        installMeteringTap()
-
-        playerNode.scheduleBuffer(buffer, at: nil, options: []) { [weak self] in
-            self?.teardownMeteringTap()
-            DispatchQueue.main.async { onFinished() }
-        }
-        playerNode.play()
+        return buffer
     }
 
-    func stop() {
-        if playerNode.isPlaying {
-            playerNode.stop()
-        }
-        teardownMeteringTap()
-    }
-
-    var isPlaying: Bool { playerNode.isPlaying }
-
-    // MARK: - Output level metering (drives the widget's audio bars)
-
-    private func installMeteringTap() {
-        guard !tapInstalled else { return }
+    /// Installs the output-level tap exactly once and never removes it. Calling `removeTap`
+    /// from the playback-completion handler (audio thread) while `stop()` also removes it
+    /// (main thread) deadlocked AVAudioEngine and froze the app. The tap is cheap and gated
+    /// on `isPlaying`.
+    private func installMeteringTapIfNeeded() {
+        guard !meteringTapInstalled else { return }
         engine.mainMixerNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
+            guard let self, self.playerNode.isPlaying else { return }
             let level = TTSPlayer.rms(buffer)
-            DispatchQueue.main.async { self?.onLevel?(level) }
+            DispatchQueue.main.async { self.onLevel?(level) }
         }
-        tapInstalled = true
+        meteringTapInstalled = true
     }
 
-    private func teardownMeteringTap() {
-        guard tapInstalled else { return }
-        engine.mainMixerNode.removeTap(onBus: 0)
-        tapInstalled = false
+    private func emitSilence() {
         DispatchQueue.main.async { [weak self] in self?.onLevel?(0) }
     }
 


### PR DESCRIPTION
## Fix: app froze when stopping Read Aloud
The metering tap (#229) called `removeTap` from the playback-completion handler (audio thread, fired when `stop()` flushes the buffer) **while** `stop()` removed it on the main thread — that race **deadlocked AVAudioEngine and froze the whole app**. Now the tap is installed once and never removed in hot paths (gated on `isPlaying`); `stop()` no longer touches it.

## Speed: chunked streaming
Read Aloud now splits the selection into **sentence chunks** and streams them — the **first sentence plays the moment it's synthesized** while the rest synthesize in the background, instead of waiting for the entire selection. New `TTSPlayer` streaming queue (`startStreaming`/`enqueue`/`finishEnqueueing`). Combined with the Kokoro pre-warm (#230), time-to-first-audio is dramatically shorter.

Build verified. Part of epic #220.