### PR TITLE
Smart Read Aloud + on-device LLM enrichment (Gemma 4) — v2.1.0

### DIFF
--- a/native-macos/Zerm.xcodeproj/project.pbxproj
+++ b/native-macos/Zerm.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		E1F350122F1D10D600790A2C /* whisper.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1A0BD052EB1E7B800266859 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D7A1C0DE0000000000000001 /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A1C0DE0000000000000002 /* sherpa-onnx.xcframework */; };
 		D7A1C0DE0000000000000003 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A1C0DE0000000000000004 /* onnxruntime.xcframework */; };
+		D7A1C0DE0000000000000005 /* llama.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A1C0DE0000000000000007 /* llama.xcframework */; };
+		D7A1C0DE0000000000000006 /* llama.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D7A1C0DE0000000000000007 /* llama.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				E1F350122F1D10D600790A2C /* whisper.xcframework in Embed Frameworks */,
+				D7A1C0DE0000000000000006 /* llama.xcframework in Embed Frameworks */,
 				E1D7EF9A2E35E19B00640029 /* MediaRemoteAdapter in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -64,6 +67,7 @@
 		E1A0BD052EB1E7B800266859 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "$(HOME)/Zerm-Dependencies/whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 		D7A1C0DE0000000000000002 /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "$(HOME)/Zerm-Dependencies/sherpa-onnx/build-swift-macos/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
 		D7A1C0DE0000000000000004 /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "onnxruntime.xcframework"; path = "$(HOME)/Zerm-Dependencies/sherpa-onnx/build-swift-macos/onnxruntime.xcframework"; sourceTree = "<group>"; };
+		D7A1C0DE0000000000000007 /* llama.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = llama.xcframework; path = "$(HOME)/Zerm-Dependencies/llama/build-apple/llama.xcframework"; sourceTree = "<group>"; };
 		E1B2DCAA2E3DE70A008DFD68 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../whisper.cpp/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 		E1CE28772E4336150082B758 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -95,6 +99,7 @@
 				E1F350112F1D10D600790A2C /* whisper.xcframework in Frameworks */,
 				D7A1C0DE0000000000000001 /* sherpa-onnx.xcframework in Frameworks */,
 				D7A1C0DE0000000000000003 /* onnxruntime.xcframework in Frameworks */,
+				D7A1C0DE0000000000000005 /* llama.xcframework in Frameworks */,
 				E1ECEC162E44591300DFFBA8 /* Zip in Frameworks */,
 				E1ADD45A2CC5352A00303ECB /* LaunchAtLogin in Frameworks */,
 				E11BBA4E2E5DC555000AB839 /* FluidAudio in Frameworks */,
@@ -152,6 +157,7 @@
 				E1A0BD052EB1E7B800266859 /* whisper.xcframework */,
 				E1CE28772E4336150082B758 /* whisper.xcframework */,
 				E1B2DCAA2E3DE70A008DFD68 /* whisper.xcframework */,
+				D7A1C0DE0000000000000007 /* llama.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -490,7 +496,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 201;
+				CURRENT_PROJECT_VERSION = 210;
 				DEVELOPMENT_ASSET_PATHS = "\"Zerm/Preview Content\"";
 				DEVELOPMENT_TEAM = V6J6A3VWY2;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -505,7 +511,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.arcusis.zerm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG ENABLE_NATIVE_SPEECH_ANALYZER $(inherited)";
@@ -531,7 +537,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 201;
+				CURRENT_PROJECT_VERSION = 210;
 				DEVELOPMENT_ASSET_PATHS = "\"Zerm/Preview Content\"";
 				DEVELOPMENT_TEAM = V6J6A3VWY2;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -546,7 +552,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.arcusis.zerm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "ENABLE_NATIVE_SPEECH_ANALYZER $(inherited)";

--- a/native-macos/Zerm/LocalLLM/LlamaBridge.h
+++ b/native-macos/Zerm/LocalLLM/LlamaBridge.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Thin Objective-C wrapper around llama.cpp. This exists purely to keep the llama/ggml C
+/// headers out of Swift: whisper.cpp also vendors `ggml`, and importing both ggml-bearing
+/// Clang modules into Swift triggers a redefinition clash. By confining `#import <llama/llama.h>`
+/// to one Objective-C++ translation unit, Swift only ever sees this Foundation-only interface.
+@interface LlamaBridge : NSObject
+
+- (instancetype)initWithModelPath:(NSString *)modelPath;
+
+/// Loads the model, context, and sampler. Idempotent. Returns NO on failure.
+- (BOOL)load;
+
+/// Runs one instruction-style generation (system + user → assistant text).
+/// `isCancelled` is polled between tokens; return YES to stop early. Returns nil on failure.
+- (nullable NSString *)generateWithSystem:(NSString *)system
+                                     user:(NSString *)user
+                             maxNewTokens:(int)maxNewTokens
+                              isCancelled:(BOOL (^_Nullable)(void))isCancelled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/native-macos/Zerm/LocalLLM/LlamaBridge.mm
+++ b/native-macos/Zerm/LocalLLM/LlamaBridge.mm
@@ -1,0 +1,157 @@
+#import "LlamaBridge.h"
+#import <llama/llama.h>
+#import <os/log.h>
+
+#include <string>
+#include <vector>
+
+@implementation LlamaBridge {
+    std::string _modelPath;
+    llama_model   * _model;
+    llama_context * _ctx;
+    const llama_vocab * _vocab;
+    llama_sampler * _sampler;
+}
+
+- (instancetype)initWithModelPath:(NSString *)modelPath {
+    if ((self = [super init])) {
+        _modelPath = std::string(modelPath.UTF8String);
+        _model = nullptr;
+        _ctx = nullptr;
+        _vocab = nullptr;
+        _sampler = nullptr;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    if (_sampler) llama_sampler_free(_sampler);
+    if (_ctx)     llama_free(_ctx);
+    if (_model)   llama_model_free(_model);
+}
+
+- (BOOL)load {
+    if (_model) return YES;
+
+    // llama.cpp's global backend must be initialized exactly once per process.
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ llama_backend_init(); });
+
+    llama_model_params mparams = llama_model_default_params();
+    mparams.n_gpu_layers = 999;   // offload everything to Metal; falls back gracefully
+
+    _model = llama_model_load_from_file(_modelPath.c_str(), mparams);
+    if (!_model) return NO;
+    _vocab = llama_model_get_vocab(_model);
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx = 4096;
+    int threads = (int)NSProcessInfo.processInfo.activeProcessorCount - 2;
+    if (threads < 2) threads = 2;
+    if (threads > 8) threads = 8;
+    cparams.n_threads = threads;
+    cparams.n_threads_batch = threads;
+
+    _ctx = llama_init_from_model(_model, cparams);
+    if (!_ctx) {
+        llama_model_free(_model);
+        _model = nullptr; _vocab = nullptr;
+        return NO;
+    }
+
+    // Low-temperature chain so the rewrite stays faithful to the source text.
+    _sampler = llama_sampler_chain_init(llama_sampler_chain_default_params());
+    llama_sampler_chain_add(_sampler, llama_sampler_init_top_k(40));
+    llama_sampler_chain_add(_sampler, llama_sampler_init_top_p(0.95f, 1));
+    llama_sampler_chain_add(_sampler, llama_sampler_init_temp(0.4f));
+    llama_sampler_chain_add(_sampler, llama_sampler_init_dist(LLAMA_DEFAULT_SEED));
+    return YES;
+}
+
+- (nullable NSString *)generateWithSystem:(NSString *)system
+                                     user:(NSString *)user
+                             maxNewTokens:(int)maxNewTokens
+                              isCancelled:(BOOL (^)(void))isCancelled {
+    if (![self load]) return nil;
+
+    // Fresh state for every request (we reuse one context).
+    llama_memory_clear(llama_get_memory(_ctx), true);
+    llama_sampler_reset(_sampler);
+
+    std::string combined = std::string(system.UTF8String) + "\n\n" + std::string(user.UTF8String);
+    std::string prompt = [self buildPrompt:combined];
+
+    std::vector<llama_token> tokens = [self tokenize:prompt addSpecial:true];
+    if (tokens.empty()) return nil;
+
+    const int nCtx = (int)llama_n_ctx(_ctx);
+    if ((int)tokens.size() > nCtx - 128) {
+        tokens.erase(tokens.begin(), tokens.end() - (nCtx - 128));   // keep most recent context
+    }
+
+    std::string out;
+    int generated = 0;
+    std::vector<llama_token> current = tokens;
+
+    while (generated < maxNewTokens) {
+        if (isCancelled && isCancelled()) break;
+
+        llama_batch batch = llama_batch_get_one(current.data(), (int32_t)current.size());
+        if (llama_decode(_ctx, batch) != 0) break;
+
+        llama_token id = llama_sampler_sample(_sampler, _ctx, -1);
+        if (llama_vocab_is_eog(_vocab, id)) break;
+
+        out += [self pieceFor:id];
+        generated++;
+        current.assign(1, id);
+    }
+
+    NSString *result = [NSString stringWithUTF8String:out.c_str()];
+    return [result stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+}
+
+// MARK: - Helpers
+
+/// Builds the prompt using the model's own chat template (so any GGUF instruct model works),
+/// folding the instructions into a single user turn. Falls back to the Gemma format.
+- (std::string)buildPrompt:(const std::string &)content {
+    const char * tmpl = llama_model_chat_template(_model, nullptr);
+    if (tmpl != nullptr) {
+        llama_chat_message msg;
+        msg.role = "user";
+        msg.content = content.c_str();
+        int32_t needed = llama_chat_apply_template(tmpl, &msg, 1, true, nullptr, 0);
+        if (needed > 0) {
+            std::vector<char> buf(needed);
+            int32_t n = llama_chat_apply_template(tmpl, &msg, 1, true, buf.data(), (int32_t)buf.size());
+            if (n > 0) return std::string(buf.data(), n);
+        }
+    }
+    return "<start_of_turn>user\n" + content + "<end_of_turn>\n<start_of_turn>model\n";
+}
+
+- (std::vector<llama_token>)tokenize:(const std::string &)text addSpecial:(bool)addSpecial {
+    int32_t byteCount = (int32_t)text.size();
+    int32_t capacity = byteCount + 16;
+    std::vector<llama_token> tokens(capacity);
+    int32_t n = llama_tokenize(_vocab, text.c_str(), byteCount,
+                               tokens.data(), capacity, addSpecial, true);
+    if (n < 0) return {};
+    tokens.resize(n);
+    return tokens;
+}
+
+- (std::string)pieceFor:(llama_token)token {
+    char buf[64];
+    int32_t n = llama_token_to_piece(_vocab, token, buf, (int32_t)sizeof(buf), 0, false);
+    if (n < 0) {
+        std::vector<char> big(-n);
+        n = llama_token_to_piece(_vocab, token, big.data(), (int32_t)big.size(), 0, false);
+        if (n < 0) return "";
+        return std::string(big.data(), n);
+    }
+    return std::string(buf, n);
+}
+
+@end

--- a/native-macos/Zerm/LocalLLM/LlamaEngine.swift
+++ b/native-macos/Zerm/LocalLLM/LlamaEngine.swift
@@ -1,0 +1,39 @@
+import Foundation
+import os
+
+/// Serializes on-device LLM inference off the main thread — the LLM counterpart of
+/// `KokoroEngine`. The actual llama.cpp work lives in `LlamaBridge` (Objective-C++) so the
+/// llama/ggml headers never reach Swift (they would clash with whisper.cpp's vendored ggml).
+actor LlamaEngine {
+    enum LlamaError: LocalizedError {
+        case loadFailed, generateFailed
+        var errorDescription: String? {
+            switch self {
+            case .loadFailed: return "Failed to load the on-device model."
+            case .generateFailed: return "On-device generation failed."
+            }
+        }
+    }
+
+    private let bridge: LlamaBridge
+
+    init(modelPath: String) {
+        bridge = LlamaBridge(modelPath: modelPath)
+    }
+
+    /// Loads the model without generating, so the first real request is fast.
+    func warmUp() throws {
+        guard bridge.load() else { throw LlamaError.loadFailed }
+    }
+
+    /// Runs one instruction-style generation. `isCancelled` is polled between tokens.
+    func generate(system: String, user: String, maxNewTokens: Int = 400,
+                  isCancelled: @escaping @Sendable () -> Bool = { false }) throws -> String {
+        guard let result = bridge.generate(withSystem: system, user: user,
+                                           maxNewTokens: Int32(maxNewTokens),
+                                           isCancelled: { isCancelled() }) else {
+            throw LlamaError.generateFailed
+        }
+        return result
+    }
+}

--- a/native-macos/Zerm/LocalLLM/LocalLLMModelManager.swift
+++ b/native-macos/Zerm/LocalLLM/LocalLLMModelManager.swift
@@ -1,0 +1,157 @@
+import Foundation
+import os
+
+/// Describes the downloadable on-device LLM (a single GGUF file).
+struct LocalLLMPackage {
+    let fileName: String
+    let displayName: String
+    let approxSize: String
+    let downloadURL: URL
+}
+
+/// Downloads, stores, and serves Zerm's on-device language model — the third local model
+/// alongside Whisper (speech-to-text) and Kokoro (text-to-speech). Same UX as both: first
+/// use auto-downloads with a progress bar, then everything runs offline.
+///
+/// Powers Read Aloud's "Natural reading" rewrite today; reusable for local AI Enhancement.
+@MainActor
+final class LocalLLMModelManager: ObservableObject {
+    static let shared = LocalLLMModelManager()
+
+    /// Gemma 4 E2B Instruct, 4-bit (Q4_K_M) — the smallest/latest Gemma, on-device optimized
+    /// (Per-Layer Embeddings). The default "agentic" model powering both AI Enhancement and
+    /// Read Aloud naturalization. Users can swap in other GGUF models (see model management).
+    static let package = LocalLLMPackage(
+        fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+        displayName: "Gemma 4 E2B (on-device)",
+        approxSize: "~3.1 GB",
+        downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf")!
+    )
+
+    @Published private(set) var isInstalled = false
+    @Published private(set) var isDownloading = false
+    /// 0.0–1.0 while downloading; nil when idle.
+    @Published private(set) var downloadProgress: Double?
+    @Published private(set) var statusText: String?
+
+    let modelsDirectory: URL
+    private let logger = Logger(subsystem: "com.arcusis.zerm", category: "LocalLLMModelManager")
+    private var engine: LlamaEngine?
+    private var downloadTask: URLSessionDownloadTask?
+    private var progressObservation: NSKeyValueObservation?
+
+    private init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.arcusis.zerm")
+        modelsDirectory = appSupport.appendingPathComponent("LLMModels")
+        try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        refreshInstalled()
+    }
+
+    // MARK: - Paths
+
+    var modelPath: URL { modelsDirectory.appendingPathComponent(Self.package.fileName) }
+
+    func refreshInstalled() {
+        isInstalled = FileManager.default.fileExists(atPath: modelPath.path)
+    }
+
+    /// Thread-safe install check usable from non-main contexts (e.g. `AIService`).
+    nonisolated static var isModelDownloaded: Bool {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.arcusis.zerm")
+        let path = appSupport.appendingPathComponent("LLMModels")
+            .appendingPathComponent(package.fileName).path
+        return FileManager.default.fileExists(atPath: path)
+    }
+
+    // MARK: - Download
+
+    func download() async {
+        guard !isDownloading else { return }
+        isDownloading = true
+        downloadProgress = 0
+        statusText = "Downloading reading model…"
+        defer { isDownloading = false; downloadProgress = nil }
+
+        do {
+            let file = try await downloadFile(from: Self.package.downloadURL)
+            try? FileManager.default.removeItem(at: modelPath)
+            try FileManager.default.moveItem(at: file, to: modelPath)
+            refreshInstalled()
+            statusText = isInstalled ? nil : "Download incomplete"
+        } catch is CancellationError {
+            statusText = "Download cancelled"
+        } catch {
+            logger.error("LLM download failed: \(error.localizedDescription, privacy: .public)")
+            statusText = "Download failed: \(error.localizedDescription)"
+        }
+    }
+
+    func cancelDownload() {
+        downloadTask?.cancel()
+        downloadTask = nil
+    }
+
+    func delete() {
+        engine = nil
+        try? FileManager.default.removeItem(at: modelPath)
+        refreshInstalled()
+    }
+
+    /// Downloads to a temp file, reporting fractional progress via KVO (mirrors KokoroModelManager).
+    private func downloadFile(from url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = URLSession.shared.downloadTask(with: url) { [weak self] tempURL, response, error in
+                self?.progressObservation?.invalidate()
+                self?.progressObservation = nil
+                if let error { continuation.resume(throwing: error); return }
+                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                    continuation.resume(throwing: TTSError.http((response as? HTTPURLResponse)?.statusCode ?? -1, "download failed"))
+                    return
+                }
+                guard let tempURL else { continuation.resume(throwing: TTSError.badResponse); return }
+                do {
+                    let dest = URL(fileURLWithPath: NSTemporaryDirectory())
+                        .appendingPathComponent("llm-download-\(Self.package.fileName)")
+                    try? FileManager.default.removeItem(at: dest)
+                    try FileManager.default.moveItem(at: tempURL, to: dest)
+                    continuation.resume(returning: dest)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+            self.downloadTask = task
+            self.progressObservation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+                Task { @MainActor in self?.downloadProgress = progress.fractionCompleted }
+            }
+            task.resume()
+        }
+    }
+
+    // MARK: - Generation
+
+    /// Rewrites/answers using the on-device model. Loads it on first use.
+    func generate(system: String, user: String, maxNewTokens: Int = 400,
+                  isCancelled: @escaping @Sendable () -> Bool = { false }) async throws -> String {
+        guard isInstalled else {
+            throw TTSError.notAvailable("The on-device reading model isn't downloaded yet. Download it in Read Aloud settings.")
+        }
+        let engine = ensureEngine()
+        return try await engine.generate(system: system, user: user, maxNewTokens: maxNewTokens, isCancelled: isCancelled)
+    }
+
+    /// Pre-loads the model in the background so the first natural read is fast.
+    func prewarmIfNeeded() async {
+        guard isInstalled, TTSSettings.naturalReadingAI else { return }
+        let engine = ensureEngine()
+        try? await engine.warmUp()
+    }
+
+    private func ensureEngine() -> LlamaEngine {
+        if let engine { return engine }
+        let engine = LlamaEngine(modelPath: modelPath.path)
+        self.engine = engine
+        return engine
+    }
+}

--- a/native-macos/Zerm/Services/AIEnhancement/AIEnhancementService.swift
+++ b/native-macos/Zerm/Services/AIEnhancement/AIEnhancementService.swift
@@ -250,6 +250,16 @@ class AIEnhancementService: ObservableObject {
             }
         }
 
+        if aiService.selectedProvider == .localLLM {
+            do {
+                let result = try await LocalLLMModelManager.shared.generate(
+                    system: systemMessage, user: formattedText, maxNewTokens: 512)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch {
+                throw EnhancementError.customError(error.localizedDescription)
+            }
+        }
+
         try await waitForRateLimit()
 
         do {

--- a/native-macos/Zerm/Services/AIEnhancement/AIService.swift
+++ b/native-macos/Zerm/Services/AIEnhancement/AIService.swift
@@ -15,9 +15,10 @@ enum AIProvider: String, CaseIterable {
     case speechmatics = "Speechmatics"
     case ollama = "Ollama"
     case localCLI = "Local CLI"
+    case localLLM = "On-Device"
     case custom = "Custom"
-    
-    
+
+
     var baseURL: String {
         switch self {
         case .cerebras:
@@ -45,6 +46,8 @@ enum AIProvider: String, CaseIterable {
         case .ollama:
             return UserDefaults.standard.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         case .localCLI:
+            return ""
+        case .localLLM:
             return ""
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderBaseURL") ?? ""
@@ -77,6 +80,8 @@ enum AIProvider: String, CaseIterable {
             return UserDefaults.standard.string(forKey: "ollamaSelectedModel") ?? "mistral"
         case .localCLI:
             return "local-cli"
+        case .localLLM:
+            return LocalLLMModelManager.package.displayName
         case .custom:
             return UserDefaults.standard.string(forKey: "customProviderModel") ?? ""
         case .openRouter:
@@ -147,16 +152,18 @@ enum AIProvider: String, CaseIterable {
             return []
         case .localCLI:
             return []
+        case .localLLM:
+            return [LocalLLMModelManager.package.displayName]
         case .custom:
             return []
         case .openRouter:
             return []
         }
     }
-    
+
     var requiresAPIKey: Bool {
         switch self {
-        case .ollama, .localCLI:
+        case .ollama, .localCLI, .localLLM:
             return false
         default:
             return true
@@ -215,6 +222,8 @@ class AIService: ObservableObject {
                 return ollamaService.isConnected
             } else if provider == .localCLI {
                 return localCLIService.isConfigured
+            } else if provider == .localLLM {
+                return LocalLLMModelManager.isModelDownloaded
             } else if provider.requiresAPIKey {
                 return APIKeyManager.shared.hasAPIKey(forProvider: provider.rawValue)
             }
@@ -265,7 +274,8 @@ class AIService: ObservableObject {
            let provider = AIProvider(rawValue: savedProvider) {
             self.selectedProvider = provider
         } else {
-            self.selectedProvider = .gemini
+            // Recommend the on-device model by default — no key, fully private.
+            self.selectedProvider = .localLLM
         }
 
         if selectedProvider.requiresAPIKey {

--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -15,6 +15,7 @@ final class TTSController: ObservableObject {
     @Published var statusMessage: String?
 
     private let player = TTSPlayer()
+    private let naturalizer = TTSNaturalizer()
     private var task: Task<Void, Never>?
     private let logger = Logger(subsystem: "com.arcusis.zerm", category: "TTSController")
 
@@ -110,7 +111,9 @@ final class TTSController: ObservableObject {
         }
 
         let speed = TTSSettings.speed
-        let chunks = Self.splitIntoChunks(text)
+        let spoken = await prepareSpokenText(from: text)
+        guard !Task.isCancelled else { return }
+        let chunks = Self.splitIntoChunks(spoken)
 
         player.startStreaming { [weak self] in
             self?.isSpeaking = false
@@ -138,6 +141,23 @@ final class TTSController: ObservableObject {
             logger.error("Read Aloud failed: \(error.localizedDescription, privacy: .public)")
             endSession("Read Aloud failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Makes the selection sound human before synthesis. The on-device LLM rewrite (when enabled
+    /// and downloaded) takes precedence; otherwise the instant offline normalizer cleans it up.
+    /// Either way we fall back to the original text so Read Aloud never fails on preprocessing.
+    private func prepareSpokenText(from raw: String) async -> String {
+        if TTSSettings.naturalReadingAI, naturalizer.isModelInstalled {
+            if let rewritten = await naturalizer.naturalize(raw, isCancelled: { Task.isCancelled }),
+               !rewritten.isEmpty {
+                return rewritten
+            }
+        }
+        if TTSSettings.smartCleanup {
+            let normalized = TTSTextNormalizer.normalize(raw)
+            if !normalized.isEmpty { return normalized }
+        }
+        return raw
     }
 
     /// Splits text into sentence-based chunks. The first chunk is a single sentence (so audio

--- a/native-macos/Zerm/TextToSpeech/TTSModels.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSModels.swift
@@ -77,6 +77,8 @@ enum TTSSettings {
         static let restoreClipboard = "ttsRestoreClipboard"
         static let wordsReadAloud = "ttsWordsReadAloud"
         static let sessionsReadAloud = "ttsSessionsReadAloud"
+        static let smartCleanup = "ttsSmartCleanup"
+        static let naturalReadingAI = "ttsNaturalReadingAI"
         static func voice(for kind: TTSProviderKind) -> String { "ttsVoice_\(kind.rawValue)" }
     }
 
@@ -94,6 +96,18 @@ enum TTSSettings {
     static var speed: Double {
         get { defaults.object(forKey: Keys.speed) as? Double ?? 1.0 }
         set { defaults.set(newValue, forKey: Keys.speed) }
+    }
+
+    /// Instant, offline text cleanup (acronyms, URLs, code, symbols). On by default.
+    static var smartCleanup: Bool {
+        get { defaults.object(forKey: Keys.smartCleanup) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: Keys.smartCleanup) }
+    }
+
+    /// On-device LLM rewrite into natural spoken language. Off by default (needs the model).
+    static var naturalReadingAI: Bool {
+        get { defaults.object(forKey: Keys.naturalReadingAI) as? Bool ?? false }
+        set { defaults.set(newValue, forKey: Keys.naturalReadingAI) }
     }
 
     static func voiceID(for kind: TTSProviderKind) -> String? {

--- a/native-macos/Zerm/TextToSpeech/TTSNaturalizer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSNaturalizer.swift
@@ -1,0 +1,76 @@
+import Foundation
+import os
+
+/// The "agentic" half of smart Read Aloud: rewrites raw on-screen text into natural, spoken
+/// language using Zerm's on-device LLM (Gemma) before synthesis. Unlike `TTSTextNormalizer`
+/// (instant, mechanical), this can rephrase — turning code, logs, and errors into something a
+/// person would actually say out loud.
+///
+/// Local-first and fail-safe: if the model isn't installed or generation fails, it returns
+/// `nil` so the caller falls back to the instant normalizer. Never blocks Read Aloud entirely.
+@MainActor
+final class TTSNaturalizer {
+    private let llm: LocalLLMModelManager
+    private let logger = Logger(subsystem: "com.arcusis.zerm", category: "TTSNaturalizer")
+
+    init(llm: LocalLLMModelManager = .shared) {
+        self.llm = llm
+    }
+
+    var isModelInstalled: Bool { llm.isInstalled }
+
+    /// Returns a spoken-friendly rewrite, or `nil` to signal "use the plain/normalized text".
+    func naturalize(_ text: String, isCancelled: @escaping @Sendable () -> Bool = { false }) async -> String? {
+        guard llm.isInstalled else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        do {
+            let result = try await llm.generate(system: Self.systemPrompt, user: trimmed,
+                                                maxNewTokens: maxTokens(for: trimmed),
+                                                isCancelled: isCancelled)
+            let cleaned = Self.cleanup(result)
+            return cleaned.isEmpty ? nil : cleaned
+        } catch {
+            logger.error("Naturalize failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    /// Roughly cap output near the input length so the model rewrites rather than rambles.
+    private func maxTokens(for text: String) -> Int {
+        let approx = text.count / 3 + 64
+        return min(700, max(96, approx))
+    }
+
+    private static let systemPrompt = """
+    You prepare written text to be read aloud by a text-to-speech voice. Rewrite the user's text \
+    so it sounds natural and clear when spoken by a person — not robotic.
+
+    Rules:
+    - Keep the original meaning and all important information. Do not summarize or add new facts.
+    - Say acronyms the way a human would: spell out letter-acronyms (API → "A P I"), but keep \
+    ones pronounced as words (NASA, JSON).
+    - Convert code, file paths, URLs, symbols, and log/error lines into plain spoken language \
+    (e.g. "Error: ENOENT" → "there was a file-not-found error").
+    - Remove markup, formatting characters, and anything that shouldn't be spoken.
+    - Expand abbreviations and read numbers, units, and currency naturally.
+    - Output ONLY the text to be spoken. No preamble, no quotes, no explanations, no markdown.
+    """
+
+    /// Strips any stray quoting/preamble the model might add despite instructions.
+    private static func cleanup(_ raw: String) -> String {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Drop a leading "Sure, here is..." style preamble line if present.
+        if let range = text.range(of: #"^(here('s| is)|sure|okay)[^\n:]*:\s*"#,
+                                  options: [.regularExpression, .caseInsensitive]) {
+            text.removeSubrange(range)
+        }
+        // Unwrap surrounding quotes.
+        if text.count > 1, let first = text.first, let last = text.last,
+           (first == "\"" && last == "\"") || (first == "“" && last == "”") {
+            text = String(text.dropFirst().dropLast())
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/native-macos/Zerm/TextToSpeech/TTSTextNormalizer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSTextNormalizer.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Turns raw on-screen text into something a person would actually *say*, before it reaches
+/// the synthesizer. This is the instant, offline half of "smart" Read Aloud: it strips markup,
+/// speaks URLs/paths/code the way a human would, spells out letter-acronyms, expands common
+/// abbreviations and error codes, and collapses log/code noise — without paraphrasing.
+///
+/// It deliberately does NOT change meaning or summarize; the optional AI pass (`TTSNaturalizer`)
+/// handles true rewriting. Keeping this purely mechanical means it's fast and predictable.
+enum TTSTextNormalizer {
+
+    /// All-caps tokens that are pronounced as words — leave them alone.
+    private static let spokenAsWord: Set<String> = [
+        "NASA", "NATO", "JSON", "YAML", "SQL", "GIF", "PNG", "RAM", "ROM", "SIM",
+        "ASCII", "SCSI", "AJAX", "SaaS", "PaaS", "IaaS", "REST", "SOAP", "CRUD",
+        "MIDI", "WYSIWYG", "FAQ", "ISO", "PDF", "URL", "OK"
+    ]
+
+    /// All-caps tokens that should be spelled out letter-by-letter.
+    private static let spelledOut: Set<String> = [
+        "API", "URI", "ID", "UI", "UX", "OS", "CLI", "CPU", "GPU", "SDK", "IDE",
+        "HTTP", "HTTPS", "HTML", "CSS", "JS", "TS", "XML", "CSV", "UUID", "SSH",
+        "DNS", "IP", "TCP", "UDP", "PR", "CI", "CD", "QA", "DB", "JWT", "CDN",
+        "AWS", "GCP", "VM", "RPC", "GUI", "TTS", "STT", "LLM", "RGB", "FPS", "USB"
+    ]
+
+    /// Common error/exit codes a developer wouldn't read letter-for-letter.
+    private static let errorCodes: [String: String] = [
+        "ENOENT": "file not found",
+        "EACCES": "permission denied",
+        "EPERM": "operation not permitted",
+        "ECONNREFUSED": "connection refused",
+        "ECONNRESET": "connection reset",
+        "ETIMEDOUT": "timed out",
+        "ENOTFOUND": "not found",
+        "EADDRINUSE": "address already in use",
+        "EPIPE": "broken pipe",
+        "NaN": "not a number"
+    ]
+
+    /// File extensions worth reading as "name dot ext" rather than running together.
+    private static let fileExtensions = "swift|py|js|ts|tsx|jsx|json|yaml|yml|md|txt|sh|rb|go|rs|java|kt|cpp|hpp|c|h|html|css|scss|xml|csv|tsv|pdf|png|jpe?g|gif|svg|zip|tar|gz|log|cfg|conf|ini|toml|env|plist|lock|sql"
+
+    static func normalize(_ raw: String) -> String {
+        var text = raw
+
+        // 1. Markdown line markers (headings, bullets, quotes, ordered lists).
+        text = regexReplace(#"(?m)^\s*#{1,6}\s+"#, in: text, with: "")
+        text = regexReplace(#"(?m)^\s*[-*+]\s+"#, in: text, with: "")
+        text = regexReplace(#"(?m)^\s*>\s?"#, in: text, with: "")
+        text = regexReplace(#"(?m)^\s*\d+[.)]\s+"#, in: text, with: "")
+
+        // 2. Fenced code blocks: drop the fences, keep the contents.
+        text = regexReplace(#"```[A-Za-z0-9_+-]*\n?"#, in: text, with: " ")
+
+        // 3. Inline code, images, links → keep the human-readable part only.
+        text = regexReplace("`([^`]+)`", in: text, with: "$1")
+        text = regexReplace(#"!\[([^\]]*)\]\([^)]*\)"#, in: text, with: "$1")
+        text = regexReplace(#"\[([^\]]+)\]\([^)]*\)"#, in: text, with: "$1")
+
+        // 4. Emails, URLs, absolute paths → spoken forms (before generic dot/slash handling).
+        text = matchReplace("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}", in: text) { speakEmail($0) }
+        text = matchReplace("(?:https?://|www\\.)[^\\s]+", in: text) { speakURL($0) }
+        text = matchReplace("(?:(?<=\\s)|^)/[A-Za-z0-9._/-]+", in: text) { speakPath($0) }
+
+        // 5. "name.ext" → "name dot ext".
+        text = regexReplace("([A-Za-z0-9_-]+)\\.(\(fileExtensions))\\b", in: text, with: "$1 dot $2",
+                            options: [.caseInsensitive])
+
+        // 6. Acronyms: spell out letter-acronyms, leave word-acronyms alone.
+        text = matchReplace("\\b[A-Za-z]{2,6}s?\\b", in: text) { speakAcronym($0) }
+
+        // 7. snake_case / kebab-ish underscores and camelCase → spaced words.
+        text = regexReplace("([A-Za-z0-9])_([A-Za-z0-9])", in: text, with: "$1 $2")
+        text = regexReplace("([a-z0-9])([A-Z])", in: text, with: "$1 $2")
+
+        // 8. Emphasis markers and stray symbols that shouldn't be spoken.
+        text = regexReplace("[*~]{1,3}", in: text, with: "")
+
+        // 9. Error codes → plain English.
+        for (code, spoken) in errorCodes {
+            text = regexReplace("\\b\(code)\\b", in: text, with: spoken)
+        }
+
+        // 10. Common abbreviations.
+        text = regexReplace("\\be\\.g\\.", in: text, with: "for example", options: [.caseInsensitive])
+        text = regexReplace("\\bi\\.e\\.", in: text, with: "that is", options: [.caseInsensitive])
+        text = regexReplace("\\betc\\.?", in: text, with: "and so on", options: [.caseInsensitive])
+        text = regexReplace("\\bvs\\.?", in: text, with: "versus", options: [.caseInsensitive])
+        text = regexReplace("\\bapprox\\.", in: text, with: "approximately", options: [.caseInsensitive])
+
+        // 11. Symbols → words.
+        text = regexReplace("\\$(\\d[\\d,]*(?:\\.\\d+)?)", in: text, with: "$1 dollars")
+        text = regexReplace("(\\d)\\s*%", in: text, with: "$1 percent")
+        text = regexReplace("#(\\d+)", in: text, with: "number $1")
+        text = regexReplace("\\s&\\s", in: text, with: " and ")
+
+        // 12. Collapse layout whitespace into sentence flow.
+        text = regexReplace("\\n{2,}", in: text, with: ". ")
+        text = regexReplace("\\s*\\n\\s*", in: text, with: " ")
+        text = regexReplace("[ \\t]{2,}", in: text, with: " ")
+        text = regexReplace("\\s+([.,;:!?])", in: text, with: "$1")
+        text = regexReplace("([.])\\1{1,}", in: text, with: ".")
+
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Spoken-form transforms
+
+    private static func speakEmail(_ email: String) -> String {
+        let parts = email.split(separator: "@", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { return email }
+        return parts[0] + " at " + parts[1].replacingOccurrences(of: ".", with: " dot ")
+    }
+
+    private static func speakURL(_ url: String) -> String {
+        var host = url
+        if let range = host.range(of: "://") { host = String(host[range.upperBound...]) }
+        host = host.split(whereSeparator: { $0 == "/" || $0 == "?" || $0 == "#" }).first.map(String.init) ?? host
+        if host.lowercased().hasPrefix("www.") { host = String(host.dropFirst(4)) }
+        return host.replacingOccurrences(of: ".", with: " dot ")
+    }
+
+    private static func speakPath(_ path: String) -> String {
+        path.split(separator: "/").joined(separator: " ")
+    }
+
+    /// Spells out letter-acronyms ("API" → "A P I"); preserves plural "s" and word-acronyms.
+    private static func speakAcronym(_ token: String) -> String {
+        var core = token
+        var plural = false
+        if core.count > 2, core.hasSuffix("s"), core.dropLast().allSatisfy(\.isUppercase) {
+            core = String(core.dropLast())
+            plural = true
+        }
+        guard core == core.uppercased(), core.allSatisfy(\.isLetter) else { return token }
+        if spokenAsWord.contains(core) { return token }
+        guard spelledOut.contains(core) else { return token }
+        let spelled = core.map(String.init).joined(separator: " ")
+        return plural ? spelled + "s" : spelled
+    }
+
+    // MARK: - Regex helpers
+
+    private static func regexReplace(_ pattern: String, in text: String, with template: String,
+                                     options: NSRegularExpression.Options = []) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: template)
+    }
+
+    private static func matchReplace(_ pattern: String, in text: String,
+                                     options: NSRegularExpression.Options = [],
+                                     _ transform: (String) -> String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else { return text }
+        let nsRange = NSRange(text.startIndex..., in: text)
+        var result = text
+        for match in regex.matches(in: text, range: nsRange).reversed() {
+            guard let r = Range(match.range, in: result) else { continue }
+            result.replaceSubrange(r, with: transform(String(result[r])))
+        }
+        return result
+    }
+}

--- a/native-macos/Zerm/Views/AI Models/APIKeyManagementView.swift
+++ b/native-macos/Zerm/Views/AI Models/APIKeyManagementView.swift
@@ -27,7 +27,15 @@ struct APIKeyManagementView: View {
                 .pickerStyle(.automatic)
                 .tint(.blue)
                 
-                if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama {
+                if aiService.selectedProvider == .localLLM {
+                    Spacer()
+                    Circle()
+                        .fill(LocalLLMModelManager.isModelDownloaded ? Color.green : Color.orange)
+                        .frame(width: 8, height: 8)
+                    Text(LocalLLMModelManager.isModelDownloaded ? "Ready" : "Not downloaded")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                } else if aiService.isAPIKeyValid && aiService.selectedProvider != .ollama {
                     Spacer()
                     Circle()
                         .fill(Color.green)
@@ -271,7 +279,13 @@ struct APIKeyManagementView: View {
                             .help("Skip the test request and save directly. Use when your gateway rejects the verification probe.")
                         }
                     }
-                    
+
+                } else if aiService.selectedProvider == .localLLM {
+                    Text("Runs entirely on your Mac — no API key, nothing leaves the device. Used to clean up dictation and to make Read Aloud sound natural.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    LocalLLMModelCardView()
+
                 } else {
                     if aiService.isAPIKeyValid {
                         HStack {

--- a/native-macos/Zerm/Views/AI Models/LocalLLMModelCardView.swift
+++ b/native-macos/Zerm/Views/AI Models/LocalLLMModelCardView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Reusable management card for Zerm's on-device language model (Gemma). Mirrors the voice
+/// model cards: shows size, a one-tap download with progress, installed state, and delete.
+/// Shared by the AI Models / Enhancement screen and Read Aloud settings so model management
+/// looks and behaves the same everywhere.
+struct LocalLLMModelCardView: View {
+    @ObservedObject private var manager = LocalLLMModelManager.shared
+
+    var body: some View {
+        let pkg = LocalLLMModelManager.package
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: "brain")
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(pkg.displayName).font(.subheadline.weight(.medium))
+                    Text("Private, on-device. No API key. Recommended.")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(pkg.approxSize).font(.caption).foregroundStyle(.secondary)
+            }
+
+            if manager.isInstalled {
+                HStack {
+                    Label("Downloaded — runs fully offline", systemImage: "checkmark.circle.fill")
+                        .font(.caption).foregroundStyle(.green)
+                    Spacer()
+                    Button(role: .destructive) { manager.delete() } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                    .controlSize(.small)
+                }
+            } else if manager.isDownloading {
+                VStack(alignment: .leading, spacing: 6) {
+                    ProgressView(value: manager.downloadProgress ?? 0)
+                    HStack {
+                        Text(manager.statusText ?? "Downloading…")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        if let p = manager.downloadProgress {
+                            Text("\(Int(p * 100))%").font(.caption.monospacedDigit())
+                        }
+                        Button("Cancel") { manager.cancelDownload() }.controlSize(.small)
+                    }
+                }
+            } else {
+                HStack {
+                    Text("Download once to enable on-device AI. No API key needed.")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Spacer()
+                    Button { Task { await manager.download() } } label: {
+                        Label("Download model", systemImage: "arrow.down.circle")
+                    }
+                    .controlSize(.small)
+                }
+                if let status = manager.statusText {
+                    Text(status).font(.caption).foregroundStyle(.red)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.primary.opacity(0.04)))
+    }
+}

--- a/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
+++ b/native-macos/Zerm/Views/Settings/TextToSpeechSettingsView.swift
@@ -6,6 +6,8 @@ struct TextToSpeechSettingsView: View {
     @AppStorage(TTSSettings.Keys.enabled) private var enabled = true
     @AppStorage(TTSSettings.Keys.provider) private var providerRaw = TTSProviderKind.deepgram.rawValue
     @AppStorage(TTSSettings.Keys.speed) private var speed = 1.0
+    @AppStorage(TTSSettings.Keys.smartCleanup) private var smartCleanup = true
+    @AppStorage(TTSSettings.Keys.naturalReadingAI) private var naturalReadingAI = false
 
     @State private var voiceID: String = ""
     @State private var apiKey: String = ""
@@ -17,6 +19,7 @@ struct TextToSpeechSettingsView: View {
     @EnvironmentObject private var ttsController: TTSController
 
     @ObservedObject private var kokoro = KokoroModelManager.shared
+    @ObservedObject private var localLLM = LocalLLMModelManager.shared
     @EnvironmentObject private var hotkeyManager: HotkeyManager
 
     private enum VerifyState: Equatable {
@@ -53,6 +56,8 @@ struct TextToSpeechSettingsView: View {
                     }
                     .padding(8)
                 }
+
+                smartReadingSection
 
                 if provider.requiresAPIKey {
                     apiKeySection
@@ -160,6 +165,37 @@ struct TextToSpeechSettingsView: View {
                     .foregroundStyle(.secondary)
             }
             Slider(value: $speed, in: 0.5...2.0, step: 0.05)
+        }
+    }
+
+    /// Smart reading: instant rules (always available) + the on-device LLM rewrite.
+    private var smartReadingSection: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Smart reading")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Smart text cleanup", isOn: $smartCleanup)
+                    Text("Instantly reads acronyms, URLs, file paths, code, and symbols the way a person would — offline, no delay.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Natural reading (AI)", isOn: $naturalReadingAI)
+                        .disabled(!localLLM.isInstalled)
+                    Text("Rewrites text into natural spoken language using Zerm's on-device model before reading. Fully offline; adds a moment before the first word.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                LocalLLMModelCardView()
+            }
+            .padding(8)
+        }
+        .onChange(of: naturalReadingAI) { _, on in
+            if on { Task { await localLLM.prewarmIfNeeded() } }
         }
     }
 

--- a/native-macos/Zerm/Zerm-Bridging-Header.h
+++ b/native-macos/Zerm/Zerm-Bridging-Header.h
@@ -5,5 +5,6 @@
 #define SWIFT_API_EXAMPLES_SHERPAONNX_BRIDGING_HEADER_H_
 
 #import "sherpa-onnx/c-api/c-api.h"
+#import "LocalLLM/LlamaBridge.h"
 
 #endif  // SWIFT_API_EXAMPLES_SHERPAONNX_BRIDGING_HEADER_H_

--- a/native-macos/Zerm/Zerm.swift
+++ b/native-macos/Zerm/Zerm.swift
@@ -176,8 +176,9 @@ struct ZermApp: App {
             await recorderUIManager.resetOnLaunch()
         }
 
-        // Pre-warm the on-device Read Aloud model so the first read is instant.
+        // Pre-warm the on-device Read Aloud models so the first read is instant.
         Task { await KokoroModelManager.shared.prewarmIfNeeded() }
+        Task { await LocalLLMModelManager.shared.prewarmIfNeeded() }
 
         AppShortcuts.updateAppShortcutParameters()
 


### PR DESCRIPTION
Adds Zerm's third on-device model (Gemma 4 E2B) and makes Read Aloud sound human, with an on-device AI Enhancement provider that shares the same model.

## What
- **Smart text cleanup** (instant, offline, default on): acronyms, URLs, paths, code, symbols, error codes, markdown.
- **Natural reading (AI)** (opt-in): on-device LLM rewrite into natural spoken prose; local-first, falls back to the normalizer on any failure.
- **On-device LLM via llama.cpp**: Gemma 4 E2B Q4_K_M (~3.1GB), auto-downloaded like the Whisper/Kokoro models. Model-agnostic chat template so other GGUFs can be swapped in.
- **AI Enhancement** gains an on-device provider (no API key), recommended/default for new users — same model used for dictation cleanup and Read Aloud.
- Reusable model-management card shown in both the AI Models screen and Read Aloud settings.

## Safety / updates
- **Additive only** — new UserDefaults keys, a new provider enum case, model files in Application Support. No SwiftData schema change; existing settings/keys/transcripts preserved.
- New default provider applies only to users with no saved provider; Enhancement stays opt-in.
- Auto-update checks are disabled in the app (SUEnableAutomaticChecks=false), so this does not push or disturb existing local installs.

## Build
- xcodebuild Debug: BUILD SUCCEEDED. llama.framework links + embeds (Obj-C++ bridge isolates llama/ggml from whisper's ggml).
- Version 2.1.0 (build 210).