### PR TITLE
Read Aloud LLM: fix Metal exit crash, stop <end_of_turn>, tune tone

### DIFF
--- a/native-macos/Zerm/LocalLLM/LlamaBridge.mm
+++ b/native-macos/Zerm/LocalLLM/LlamaBridge.mm
@@ -35,7 +35,13 @@
 
     // llama.cpp's global backend must be initialized exactly once per process.
     static dispatch_once_t once;
-    dispatch_once(&once, ^{ llama_backend_init(); });
+    dispatch_once(&once, ^{
+        // Disable Metal residency sets: their collection is freed by a C++ static destructor at
+        // process exit, which races with its own background init and aborts (ggml_metal_rsets_free).
+        // GPU acceleration is unaffected — this only turns off a memory-residency optimization.
+        setenv("GGML_METAL_NO_RESIDENCY", "1", 1);
+        llama_backend_init();
+    });
 
     llama_model_params mparams = llama_model_default_params();
     mparams.n_gpu_layers = 999;   // offload everything to Metal; falls back gracefully
@@ -63,7 +69,7 @@
     _sampler = llama_sampler_chain_init(llama_sampler_chain_default_params());
     llama_sampler_chain_add(_sampler, llama_sampler_init_top_k(40));
     llama_sampler_chain_add(_sampler, llama_sampler_init_top_p(0.95f, 1));
-    llama_sampler_chain_add(_sampler, llama_sampler_init_temp(0.4f));
+    llama_sampler_chain_add(_sampler, llama_sampler_init_temp(0.3f));
     llama_sampler_chain_add(_sampler, llama_sampler_init_dist(LLAMA_DEFAULT_SEED));
     return YES;
 }
@@ -103,6 +109,16 @@
         if (llama_vocab_is_eog(_vocab, id)) break;
 
         out += [self pieceFor:id];
+
+        // Some small/quantized models emit the turn delimiter as literal text instead of the
+        // special token — stop there so "<end_of_turn>" is never spoken.
+        bool hitStop = false;
+        for (const char *stop : {"<end_of_turn>", "<start_of_turn>", "<eos>"}) {
+            size_t pos = out.find(stop);
+            if (pos != std::string::npos) { out.erase(pos); hitStop = true; break; }
+        }
+        if (hitStop) break;
+
         generated++;
         current.assign(1, id);
     }

--- a/native-macos/Zerm/TextToSpeech/TTSNaturalizer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSNaturalizer.swift
@@ -51,10 +51,11 @@ final class TTSNaturalizer {
     }
 
     /// Imperative, no second-person identity ("You are…" makes small models introduce themselves).
+    /// A one-shot example anchors the format for the small model and prevents chatty replies.
     private static let instruction = """
     Rewrite the text that appears after "TEXT:" so a text-to-speech voice can read it aloud \
-    naturally, the way a person would actually say it. This is a rewriting task only — do NOT \
-    answer the text, describe yourself, explain, or summarize.
+    naturally — clear, warm, and conversational, the way a person would actually say it out loud. \
+    This is a rewriting task only — do NOT answer the text, describe yourself, explain, or summarize.
 
     Rules:
     - Keep all the meaning and information. Do not add new facts.
@@ -63,7 +64,14 @@ final class TTSNaturalizer {
     (e.g. "Error: ENOENT" → "there was a file-not-found error"). Never read an emoji or symbol by \
     its name — never say things like "white heavy check mark" or "heavy right arrow".
     - Remove markup and formatting. Expand abbreviations; read numbers and currency naturally.
-    - Reply with ONLY the spoken text, nothing else.
+    - Keep it about the same length as the original. Reply with ONLY the spoken text, nothing else.
+
+    Example —
+    TEXT:
+    PR #877 merged: fixed the 42P10 dedupe index bug. Cost capture now works.
+    REWRITTEN:
+    Pull request 877 was merged. It fixed the four-two-P-ten dedupe index bug, so cost capture \
+    now works.
     """
 
     /// Rejects degenerate model output (self-introductions, refusals, or wildly off-length),
@@ -91,6 +99,10 @@ final class TTSNaturalizer {
     /// Strips any stray quoting/preamble the model might add despite instructions.
     private static func cleanup(_ raw: String) -> String {
         var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Strip chat-control tokens a small model may emit as literal text.
+        text = text.replacingOccurrences(of: #"<\/?[A-Za-z0-9_]+>"#, with: "", options: .regularExpression)
+        text = text.replacingOccurrences(of: #"\b(end|start)_of_turn\b"#, with: "",
+                                         options: [.regularExpression, .caseInsensitive])
         // Drop an echoed label or a "Sure, here is..." style preamble if present.
         if let range = text.range(of: #"^(rewritten|text|here('s| is)|sure|okay)[^\n:]*:\s*"#,
                                   options: [.regularExpression, .caseInsensitive]) {


### PR DESCRIPTION
Fixes from on-device testing:

- **Crash on quit** (ggml_metal_rsets_free abort): llama's Metal residency-set collection is freed by a C++ static destructor at process exit, racing its own background init. Set `GGML_METAL_NO_RESIDENCY=1` before backend init — disables only the memory-residency optimization; GPU inference is unaffected.
- **"end of turn" spoken**: small/quantized models emit `<end_of_turn>` as literal text; now we stop generation at the delimiter and strip leftover chat-control tokens.
- **Tone**: one-shot example + warm/conversational/same-length instruction; temperature 0.4 → 0.3.

Additive; part of v2.1.0.