### PR TITLE
Read Aloud: accurate widget status + readable tables

### DIFF
--- a/native-macos/Zerm/HotkeyManager.swift
+++ b/native-macos/Zerm/HotkeyManager.swift
@@ -71,7 +71,7 @@ class HotkeyManager: ObservableObject {
 
     // MARK: - Helper Properties
     private var canProcessHotkeyAction: Bool {
-        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy && engine.recordingState != .speaking && engine.recordingState != .preparingSpeech
+        engine.recordingState != .transcribing && engine.recordingState != .enhancing && engine.recordingState != .busy && engine.recordingState != .speaking && engine.recordingState != .preparingSpeech && engine.recordingState != .generatingSpeech
     }
     
     // NSEvent monitoring for modifier keys

--- a/native-macos/Zerm/TextToSpeech/TTSController.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSController.swift
@@ -152,9 +152,10 @@ final class TTSController: ObservableObject {
         let cleaned = base.isEmpty ? raw : base
 
         if TTSSettings.naturalReadingAI, naturalizer.isModelInstalled {
-            if let rewritten = await naturalizer.naturalize(cleaned, isCancelled: { Task.isCancelled }) {
-                return rewritten
-            }
+            recorderUIManager?.beginGenerating()          // widget shows "Thinking…"
+            let rewritten = await naturalizer.naturalize(cleaned, isCancelled: { Task.isCancelled })
+            recorderUIManager?.endGenerating()            // back to "Preparing…" for synthesis
+            if let rewritten { return rewritten }
         }
         return cleaned
     }

--- a/native-macos/Zerm/TextToSpeech/TTSNaturalizer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSNaturalizer.swift
@@ -64,6 +64,8 @@ final class TTSNaturalizer {
     (e.g. "Error: ENOENT" → "there was a file-not-found error"). Never read an emoji or symbol by \
     its name — never say things like "white heavy check mark" or "heavy right arrow".
     - Remove markup and formatting. Expand abbreviations; read numbers and currency naturally.
+    - If the text is a table or list, read it as natural sentences (row by row, mentioning the \
+    column meaning where helpful). Never read separators or column borders.
     - Keep it about the same length as the original. Reply with ONLY the spoken text, nothing else.
 
     Example —

--- a/native-macos/Zerm/TextToSpeech/TTSTextNormalizer.swift
+++ b/native-macos/Zerm/TextToSpeech/TTSTextNormalizer.swift
@@ -44,6 +44,10 @@ enum TTSTextNormalizer {
     static func normalize(_ raw: String) -> String {
         var text = raw
 
+        // 0. Tables: turn each row ("│ a │ b │" or "| a | b |") into "a, b." so cells read with
+        // pauses and rows are separate sentences, instead of a stripped-glyph run-on.
+        text = flattenTables(text)
+
         // 1. Markdown line markers (headings, bullets, quotes, ordered lists).
         text = regexReplace(#"(?m)^\s*#{1,6}\s+"#, in: text, with: "")
         text = regexReplace(#"(?m)^\s*[-*+]\s+"#, in: text, with: "")
@@ -78,6 +82,7 @@ enum TTSTextNormalizer {
 
         // 7. snake_case / kebab-ish underscores and camelCase → spaced words.
         text = regexReplace("([A-Za-z0-9])_([A-Za-z0-9])", in: text, with: "$1 $2")
+        text = regexReplace("_+", in: text, with: " ")   // strip any leftover underscores
         text = regexReplace("([a-z0-9])([A-Z])", in: text, with: "$1 $2")
 
         // 8. Emphasis markers and stray symbols that shouldn't be spoken.
@@ -109,6 +114,28 @@ enum TTSTextNormalizer {
         text = regexReplace("([.])\\1{1,}", in: text, with: ".")
 
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Tables
+
+    /// Converts table rows (Unicode box `│` or markdown `|`) into spoken "cell, cell." sentences.
+    /// Border/separator rows (only box-drawing or dashes) collapse to nothing.
+    private static func flattenTables(_ text: String) -> String {
+        guard text.contains("│") || text.contains("|") else { return text }
+        let lines = text.components(separatedBy: "\n")
+        let converted = lines.map { line -> String in
+            guard line.contains("│") || line.contains("|") else { return line }
+            let cells = line
+                .split(whereSeparator: { $0 == "│" || $0 == "|" })
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { cell in
+                    guard !cell.isEmpty else { return false }
+                    // Drop markdown separator cells like "---" or ":---:".
+                    return !cell.allSatisfy { "-:= ".contains($0) }
+                }
+            return cells.isEmpty ? "" : cells.joined(separator: ", ") + "."
+        }
+        return converted.joined(separator: "\n")
     }
 
     // MARK: - Symbols & emoji

--- a/native-macos/Zerm/Transcription/Engine/RecorderUIManager.swift
+++ b/native-macos/Zerm/Transcription/Engine/RecorderUIManager.swift
@@ -57,9 +57,10 @@ class RecorderUIManager: ObservableObject {
     /// Stops Read Aloud playback. Set by the app to TTSController.stop().
     var onCancelSpeaking: (() -> Void)?
 
-    /// True while Read Aloud owns the widget (synthesizing or playing).
+    /// True while Read Aloud owns the widget (thinking, synthesizing, or playing).
     var isReadAloudActive: Bool {
-        engine?.recordingState == .speaking || engine?.recordingState == .preparingSpeech
+        let s = engine?.recordingState
+        return s == .speaking || s == .preparingSpeech || s == .generatingSpeech
     }
 
     /// Whether Read Aloud may start — only when nothing else is using the recorder.
@@ -75,10 +76,26 @@ class RecorderUIManager: ObservableObject {
         isMiniRecorderVisible = true
     }
 
-    /// Switches the widget from "Preparing…" to the live audio bars once playback starts.
-    func markSpeechPlaying() {
+    /// Shows the "Thinking…" state while the on-device AI rewrites the text.
+    func beginGenerating() {
         guard let engine = engine else { return }
         if engine.recordingState == .preparingSpeech {
+            engine.recordingState = .generatingSpeech
+        }
+    }
+
+    /// Returns to "Preparing…" once the AI rewrite finishes and synthesis begins.
+    func endGenerating() {
+        guard let engine = engine else { return }
+        if engine.recordingState == .generatingSpeech {
+            engine.recordingState = .preparingSpeech
+        }
+    }
+
+    /// Switches the widget from the loading states to the live audio bars once playback starts.
+    func markSpeechPlaying() {
+        guard let engine = engine else { return }
+        if engine.recordingState == .preparingSpeech || engine.recordingState == .generatingSpeech {
             engine.recordingState = .speaking
         }
     }

--- a/native-macos/Zerm/Transcription/Engine/RecordingState.swift
+++ b/native-macos/Zerm/Transcription/Engine/RecordingState.swift
@@ -6,7 +6,8 @@ enum RecordingState: Equatable {
     case recording
     case transcribing
     case enhancing
-    case preparingSpeech   // Read Aloud is synthesizing — widget shows a loading indicator
+    case generatingSpeech  // Read Aloud is running the on-device AI rewrite — widget shows "Thinking…"
+    case preparingSpeech   // Read Aloud is synthesizing audio — widget shows "Preparing…"
     case speaking          // Read Aloud audio is playing — animated bars
     case busy
 }

--- a/native-macos/Zerm/Views/Recorder/AudioVisualizerView.swift
+++ b/native-macos/Zerm/Views/Recorder/AudioVisualizerView.swift
@@ -71,6 +71,7 @@ struct ProcessingStatusDisplay: View {
         case transcribing
         case enhancing
         case preparing
+        case generating
     }
 
     let mode: Mode
@@ -81,6 +82,7 @@ struct ProcessingStatusDisplay: View {
         case .transcribing: return "Transcribing"
         case .enhancing:    return "Enhancing"
         case .preparing:    return "Preparing…"
+        case .generating:   return "Thinking…"
         }
     }
 
@@ -89,6 +91,7 @@ struct ProcessingStatusDisplay: View {
         case .transcribing: return 0.18
         case .enhancing:    return 0.22
         case .preparing:    return 0.14
+        case .generating:   return 0.16
         }
     }
 

--- a/native-macos/Zerm/Views/Recorder/NotchRecorderView.swift
+++ b/native-macos/Zerm/Views/Recorder/NotchRecorderView.swift
@@ -22,7 +22,7 @@ struct NotchRecorderView<S: RecorderStateProvider & ObservableObject>: View {
         case .recording:
             let shouldShowLive = showLiveTextPreview && !stateProvider.partialTranscript.isEmpty
             return shouldShowLive ? .liveText : .active
-        case .transcribing, .enhancing, .speaking, .preparingSpeech:
+        case .transcribing, .enhancing, .speaking, .preparingSpeech, .generatingSpeech:
             return .active
         default:
             return .collapsed

--- a/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
+++ b/native-macos/Zerm/Views/Recorder/RecorderComponents.swift
@@ -314,7 +314,10 @@ struct RecorderStatusDisplay: View {
 
     var body: some View {
         Group {
-            if currentState == .preparingSpeech {
+            if currentState == .generatingSpeech {
+                // Read Aloud is running the on-device AI rewrite — show "Thinking…".
+                ProcessingStatusDisplay(mode: .generating, color: .white).transition(.opacity)
+            } else if currentState == .preparingSpeech {
                 // Read Aloud is synthesizing — show a loading indicator until audio starts.
                 ProcessingStatusDisplay(mode: .preparing, color: .white).transition(.opacity)
             } else if currentState == .speaking {


### PR DESCRIPTION
From on-device testing:

- **Widget status accuracy**: the notch now shows the real phase — "Thinking…" while the on-device AI rewrites (new `.generatingSpeech` state), "Preparing…" during synthesis, then live bars while speaking. Previously it showed one generic "Preparing…".
- **Tables**: rows (`│ a │ b │` or `| a | b |`) are flattened to "a, b." so they read with pauses as sentences; border/separator rows collapse; stray underscores stripped. AI prompt told to read tables/lists row by row and never read borders.

Verified the table normalizer on the real playoff-games table. Additive; part of v2.1.0.