### PR TITLE
docs: three-model platform — Read Aloud, on-device LLM, smart reading

### DIFF
--- a/Notebook/Zerm Architecture.md
+++ b/Notebook/Zerm Architecture.md
@@ -1,12 +1,35 @@
 # Zerm Architecture
 
+## System Overview
+
+Two flows share one engine, one state machine, and one recorder widget — and are mutually exclusive.
+
+```mermaid
+flowchart TB
+    HK[HotkeyManager] --> ENG[ZermEngine<br/>RecordingState]
+    MIC[CoreAudioRecorder] --> ENG
+    ENG --> STT[Whisper STT] --> ENH[AIEnhancementService] --> PASTE[CursorPaster]
+    HK --> TC[TTSController]
+    SEL[SelectedTextService] --> TC
+    TC --> SR{Smart Reading}
+    SR -->|always| NORM[TTSTextNormalizer]
+    SR -->|optional| LLM[Gemma llama.cpp]
+    NORM --> TTS[Kokoro TTS] --> PLAY[TTSPlayer]
+    LLM --> TTS
+    ENH -.optional.-> LLM
+    ENG --> UI[RecorderUIManager widget]
+    TC --> UI
+```
+
+See [[Zerm Three Model Platform]], [[Zerm Read Aloud]], [[Zerm Smart Reading]], [[Zerm On-Device LLM]].
+
 ## Tech Stack
 
 - **Language:** Swift 5.10+
 - **UI:** SwiftUI + AppKit (NSPanel for recording overlays)
 - **Data:** SwiftData (transcription history, vocabulary, word replacements)
-- **Audio:** CoreAudio AUHAL (`CoreAudioRecorder.swift`), AVFoundation for file processing
-- **Local AI:** whisper.cpp XCFramework (at `$(HOME)/Zerm-Dependencies/whisper.cpp/build-apple/whisper.xcframework`)
+- **Audio:** CoreAudio AUHAL (`CoreAudioRecorder.swift`) for capture, AVFoundation/AVAudioEngine for playback
+- **On-device AI (three models):** `whisper.cpp` (STT), `sherpa-onnx` + Kokoro (TTS), `llama.cpp` + Gemma (LLM) — all prebuilt XCFrameworks under `$(HOME)/Zerm-Dependencies/`
 - **Packaging:** Xcode + xcodebuild, ad-hoc signed for local dev
 - **Updates:** Sparkle 2.x (`UpdaterViewModel`)
 - **Dependencies (Swift packages):** KeyboardShortcuts 2.4.x, LaunchAtLogin-Modern, Sparkle, FluidAudio, LLMkit, swift-atomics, Zip, AXSwift, SelectedTextKit, KeySender, MediaRemoteAdapter
@@ -30,13 +53,27 @@
 
 ## Recording State Machine
 
-```
-.idle → .starting → .recording → .transcribing → .enhancing → .idle
-                                                             ↑ (via cancelRecording)
-                                               .busy (transient during dismiss)
+`RecordingState` (on `ZermEngine`) is the single source of truth; the hotkey is ignored unless the state allows it (`canProcessHotkeyAction`). Dictation and Read Aloud both start only from `.idle`, so they are mutually exclusive.
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+    idle --> starting: dictation hotkey
+    starting --> recording
+    recording --> transcribing: stop
+    transcribing --> enhancing: AI on
+    enhancing --> idle
+    transcribing --> idle
+
+    idle --> preparingSpeech: Read Aloud hotkey
+    preparingSpeech --> generatingSpeech: AI rewrite on
+    generatingSpeech --> preparingSpeech: rewrite done
+    preparingSpeech --> speaking: first audio chunk
+    speaking --> idle
+    generatingSpeech --> idle: cancelled
 ```
 
-`ZermEngine.toggleRecord()` only starts from `.idle` and only stops from `.recording`. All other states block the hotkey via `canProcessHotkeyAction`.
+The widget label is driven directly by the state: **Transcribing / Enhancing** (dictation), **Thinking… / Preparing… / live bars** (Read Aloud).
 
 ## Whisper Model Loading
 

--- a/Notebook/Zerm On-Device LLM.md
+++ b/Notebook/Zerm On-Device LLM.md
@@ -1,0 +1,47 @@
+# Zerm On-Device LLM
+
+The third local model — Gemma via `llama.cpp` — powers smart reading and AI enhancement. Code in `Zerm/LocalLLM/`.
+
+**Default:** Gemma 4 E2B Instruct Q4_K_M GGUF (~3.1 GB) from `unsloth/gemma-4-E2B-it-GGUF`. E2B is the smallest Gemma 4 (PLE, effective ~2B). Model-agnostic — uses each GGUF's built-in chat template (Gemma fallback), so other instruct models can be swapped in.
+
+## Components
+
+- `LocalLLMModelManager.swift` — singleton downloader/loader (mirrors `KokoroModelManager`).
+- `LlamaEngine.swift` — `actor` serializing inference off-main.
+- `LlamaBridge.h` / `.mm` — Objective-C++ wrapper around `llama.cpp`.
+
+## The ggml isolation problem (critical)
+
+`whisper.cpp` and `llama.cpp` both vendor **`ggml`** at different versions; both export it as a Clang module. Importing both into Swift = conflicting `ggml_op`/`ggml_type` definitions → build error.
+
+**Fix:** confine `#import <llama/llama.h>` to `LlamaBridge.mm` (one Obj-C++ TU). Swift only sees the Foundation-only `LlamaBridge` and never imports the `llama` module, so the two ggml versions are never co-imported.
+
+```mermaid
+flowchart LR
+    SW[Swift] -->|Foundation only| BR[LlamaBridge.h]
+    BR --- MM[LlamaBridge.mm<br/>imports llama.h]
+    MM --> LL[llama.framework + ggml]
+    LWS[LibWhisper.swift] -->|import whisper| WF[whisper.framework + ggml]
+```
+
+## Inference (llama.cpp b9699)
+
+`llama_model_load_from_file` → `llama_init_from_model` (`n_gpu_layers=999`, Metal). Prompt via `llama_chat_apply_template`. Decode loop: `llama_batch_get_one` → `llama_decode` → `llama_sampler_sample(-1)`, stop on `llama_vocab_is_eog`. Sampler: top-k 40 / top-p 0.95 / **temp 0.3** / dist. KV reset: `llama_memory_clear(llama_get_memory(ctx), true)`.
+
+### Runtime gotchas (fixed)
+
+- **Metal exit crash** (`ggml_metal_rsets_free` abort at process exit): set `GGML_METAL_NO_RESIDENCY=1` before `llama_backend_init()`.
+- **`<end_of_turn>` spoken**: small models emit it as literal text — stop generation at the delimiter; strip stray control tokens.
+
+## Packaging
+
+`llama.xcframework` (b9699) — dynamic, module map, **embedded + signed** (mirrors whisper). No bridging header for the framework; `.mm` includes it directly.
+
+## Consumers
+
+- Read Aloud naturalization (`TTSNaturalizer`) — see [[Zerm Smart Reading]].
+- AI enhancement (`AIProvider.localLLM`, recommended default, no key).
+
+Both share one `LocalLLMModelManager` / one loaded model.
+
+Related: [[Zerm Smart Reading]], [[Zerm Read Aloud]], [[Zerm Architecture]]

--- a/Notebook/Zerm Read Aloud.md
+++ b/Notebook/Zerm Read Aloud.md
@@ -1,0 +1,37 @@
+# Zerm Read Aloud
+
+Text-to-speech — the mirror of dictation. Select text anywhere → hotkey → Zerm speaks it (local Kokoro or cloud). Code in `Zerm/TextToSpeech/`.
+
+```mermaid
+flowchart TB
+    HK[Read Aloud hotkey] --> TC[TTSController.toggle]
+    TC --> SESS[startSession: reserve widget, Preparing…]
+    SESS --> FETCH[SelectedTextService.fetchSelectedText]
+    FETCH --> PREP[prepareSpokenText → Smart Reading]
+    PREP --> CHUNK[sentence chunks]
+    CHUNK --> SYN[provider.synthesize per chunk]
+    SYN --> Q[TTSPlayer streaming queue]
+    Q --> PLAY[AVAudioEngine playback + live bars]
+    PLAY --> DONE[endSpeaking → idle]
+```
+
+## Key types
+
+- `TTSController` — orchestrator; owns mutual exclusion with dictation via the single `RecordingState`.
+- `TTSProvider` + `TTSProviderRegistry` — provider protocol (mirrors STT `CloudProvider`). Local: Kokoro. Cloud: Deepgram, ElevenLabs, OpenAI, Gemini, Inworld, Cartesia.
+- `TTSPlayer` — one `AVAudioEngine`/`AVAudioPlayerNode` pipeline with a **streaming queue** (`startStreaming`/`enqueue`/`finishEnqueueing`).
+- `KokoroModelManager` / `KokoroEngine` — on-device download + `sherpa-onnx` synthesis.
+
+## Instant feel
+
+First sentence plays while the rest synthesizes (first chunk = 1 sentence, rest ≈220 chars). Kokoro pre-warmed on launch.
+
+## Shared widget
+
+Reuses the dictation notch/mini widget + live audio bars (TTS output level → `recorder.audioMeter`). Widget label follows `RecordingState`: **Thinking…** (`generatingSpeech`, AI rewrite) → **Preparing…** (`preparingSpeech`, synth) → **bars** (`speaking`). Double-Escape cancels.
+
+## Gotcha (fixed)
+
+Metering tap is installed **once, never removed** in hot paths — `removeTap` from the audio-thread completion handler while `stop()` also removed it deadlocked `AVAudioEngine` and froze the app.
+
+Related: [[Zerm Smart Reading]], [[Zerm On-Device LLM]], [[Zerm Three Model Platform]]

--- a/Notebook/Zerm Smart Reading.md
+++ b/Notebook/Zerm Smart Reading.md
@@ -1,0 +1,38 @@
+# Zerm Smart Reading
+
+Makes Read Aloud sound human, not robotic. Two layers; order matters. The deterministic normalizer **always runs first**; the AI layer only refines clean text and falls back on failure.
+
+```mermaid
+flowchart TB
+    RAW[Selected text] --> NORM[1 · TTSTextNormalizer<br/>instant, offline, always]
+    NORM --> AION{Natural reading AI on<br/>+ model installed?}
+    AION -->|no| OUT[Cleaned → synthesis]
+    AION -->|yes| LLM[2 · TTSNaturalizer<br/>on-device Gemma rewrite]
+    LLM --> V{Usable rewrite?}
+    V -->|yes| OUT2[Rewritten → synthesis]
+    V -->|no: self-intro / off-length| OUT
+```
+
+## Layer 1 — `TTSTextNormalizer` (instant, deterministic)
+
+Always on (`TTSSettings.smartCleanup`). Mechanical pass:
+- Letter-acronyms spelled (`API`→"A P I"), word-acronyms kept (NASA/JSON).
+- URLs/emails/paths spoken; `config.yaml`→"config dot yaml"; `ENOENT`→"file not found".
+- `$5`→"5 dollars", `95%`→"95 percent"; snake_case/camelCase split; underscores stripped.
+- Emoji: `✅`→"check", `❌`→"no", `⚠️`→"warning"; rest stripped (no "white heavy check mark").
+- **Tables flattened first**: `│ a │ b │`→"a, b." (commas=pauses, rows=sentences); borders/separators collapse.
+- Markdown + box-drawing removed.
+
+## Layer 2 — `TTSNaturalizer` (optional, on-device AI)
+
+Off by default (`TTSSettings.naturalReadingAI`); needs the [[Zerm On-Device LLM]]. Rewrites cleaned text into natural prose. Small-model scaffolding:
+- **Imperative completion prompt** (`TEXT:`…`REWRITTEN:`), not "You are…" (which makes small models self-introduce).
+- One-shot example anchors format.
+- `isUsableRewrite` validation rejects self-intros/refusals/off-length → fall back to cleaned text.
+- Temp 0.3.
+
+## Settings
+
+Read Aloud settings → **Smart reading** section: both toggles + the on-device model card. Same model/card also on the AI Models screen (for enhancement).
+
+Related: [[Zerm Read Aloud]], [[Zerm On-Device LLM]], [[Zerm Three Model Platform]]

--- a/Notebook/Zerm Three Model Platform.md
+++ b/Notebook/Zerm Three Model Platform.md
@@ -1,0 +1,25 @@
+# Zerm Three Model Platform
+
+Zerm's defining architecture: the experience is powered by **three on-device AI models**, each owned and installed by the app, each able to run fully offline.
+
+```mermaid
+flowchart LR
+    A[🎙️ Whisper<br/>Speech-to-Text] --> B[🧠 Gemma<br/>Agentic LLM]
+    C[Selected text] --> B
+    B --> D[🔊 Kokoro<br/>Text-to-Speech]
+    A -. or paste .-> P[Cursor]
+```
+
+The middle model (**Gemma**) is the agentic layer serving *both* sides: it cleans speech-to-text output for accuracy and de-robotizes text-to-speech.
+
+| | STT | TTS | LLM |
+|---|---|---|---|
+| Default | Whisper (ggml) | Kokoro-82M | Gemma 4 E2B Q4_K_M |
+| Engine | `whisper.cpp` | `sherpa-onnx` | `llama.cpp` |
+| ~Size | 150 MB–3 GB | ~330 MB | ~3.1 GB |
+| Manager | `WhisperModelManager` | `KokoroModelManager` | `LocalLLMModelManager` |
+| Path | `…/WhisperModels/` | `…/TTSModels/` | `…/LLMModels/` |
+
+All live under `~/Library/Application Support/com.arcusis.zerm/` (outside the bundle → survive reinstalls). Every model uses the same download UX (manager classes are mirrors); cloud providers remain optional per task.
+
+Related: [[Zerm Read Aloud]], [[Zerm On-Device LLM]], [[Zerm Smart Reading]], [[Zerm Architecture]]

--- a/Notebook/_INDEX_Main.md
+++ b/Notebook/_INDEX_Main.md
@@ -1,6 +1,6 @@
 # Zerm Notebook
 
-Last updated: 2026-05-22
+Last updated: 2026-06-21
 
 This notebook captures durable project context for Zerm. Start here, then follow the linked notes relevant to the task.
 
@@ -8,23 +8,29 @@ This notebook captures durable project context for Zerm. Start here, then follow
 
 - [[Zerm Overview]]
 - [[Zerm Architecture]]
+- [[Zerm Three Model Platform]] — the STT + TTS + LLM design
+- [[Zerm Read Aloud]] — text-to-speech subsystem
+- [[Zerm On-Device LLM]] — Gemma via llama.cpp
+- [[Zerm Smart Reading]] — human-sounding read-aloud
 - [[Zerm Runtime Privacy Model]]
 - [[Zerm Auto Paste]]
 - [[Zerm Setup And Permissions]]
 - [[Zerm Production History]]
 - [[Zerm Known Follow Ups]]
 
-## Current State (2026-05-22)
+## Current State (2026-06-21)
 
-- Branch: `Production`  
-- Latest release: `v1.0.0` (Apple Silicon DMG only — Intel build not yet available)
-- **The Tauri prototype has been fully removed.** Zerm is now a pure native macOS Swift/SwiftUI app.
-- All upstream VoiceInk issues tracked in `arcusis/Zerm` GitHub Issues (~168 open).
+- Branch: `Production` · Version: `2.1.0` (build 210)
+- **Repo is flat:** the Xcode project lives at the **repository root** (`Zerm.xcodeproj`), matching VoiceInk. The old `native-macos/` nesting (a Tauri-era vestige) is gone.
+- **Three on-device models:** Whisper (STT), Kokoro (TTS), Gemma (agentic LLM) — each auto-downloaded and managed in-app; cloud providers optional per task.
+- **Read Aloud** ships with smart reading (instant cleanup + optional on-device AI rewrite).
+- CI builds the Swift app on every PR (all actions SHA-pinned per repo policy).
 
 ## Quick Build Reference
 
 ```bash
-make local         # build + install to ~/Applications (unsigned, local dev)
+# From the repo root
+make install            # build + ad-hoc sign + install to /Applications (resets TCC)
 make reset-permissions  # tccutil reset Accessibility + ScreenCapture
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,24 @@ Additional attribution details are kept in [NOTICE](./NOTICE).
 
 ## Features
 
-- **Fast dictation workflow** for recording, transcribing, and inserting text.
-- **Native macOS app** built in Swift and SwiftUI.
-- **Global shortcuts** and push-to-talk style recording.
-- **Auto-stop and auto-paste** so a dictation can finish and insert text with minimal friction.
-- **Power Mode** to adapt prompts based on the active app, website, or workflow.
-- **AI enhancement prompts** for cleanup, rewriting, assistant-style responses, and custom modes.
-- **Local model support** through Whisper and FluidAudio-backed transcription paths.
-- **Cloud transcription providers** for users who explicitly configure external services.
-- **Personal dictionary** with vocabulary and word replacement support.
-- **History and audio-file transcription** for reviewing or processing previous recordings.
-- **macOS permissions flow** for microphone, Accessibility, screen context, and automation-related capabilities.
+Zerm is built around **three on-device AI models** the app downloads and manages for you — speech-to-text, text-to-speech, and a small agentic LLM — so the core experience is fast, private, and works offline. Cloud providers remain available for every task as an option.
+
+| Model | Job | Engine |
+| --- | --- | --- |
+| 🎙️ Whisper | Speech-to-Text (dictation) | `whisper.cpp` |
+| 🔊 Kokoro | Text-to-Speech (Read Aloud) | `sherpa-onnx` |
+| 🧠 Gemma | Agentic layer (smart reading + enhancement) | `llama.cpp` |
+
+- **Fast dictation workflow** — global shortcut, push-to-talk recording, auto-stop, and auto-paste at the cursor.
+- **Read Aloud** — select text anywhere, press a shortcut, and Zerm reads it in a natural voice (local Kokoro or cloud).
+- **Smart Reading** — text is cleaned (acronyms, URLs, code, emoji, tables) and optionally rewritten by the on-device LLM so it sounds human, not robotic.
+- **On-device AI enhancement** — clean up and reformat dictated text with the local Gemma model (no API key) or a cloud provider.
+- **Power Mode** — adapt prompts based on the active app, website, or workflow.
+- **Local + cloud everywhere** — Whisper/FluidAudio/Apple for STT; Kokoro for TTS; Gemma/Ollama for the LLM — plus cloud providers you explicitly configure.
+- **Personal dictionary**, **history**, and **audio-file transcription**.
+- **Explicit macOS permissions flow** for microphone, Accessibility, and screen context.
+
+See the [project wiki](https://github.com/arcusis/Zerm/wiki) for architecture and subsystem docs.
 
 ## Install
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Zerm - macOS voice dictation</title>
+    <title>Zerm - on-device voice for macOS (dictation + read aloud)</title>
     <meta
       name="description"
-      content="Zerm is a GPLv3 macOS voice dictation app based on VoiceInk, with native transcription workflows, Power Mode, and auto-paste."
+      content="Zerm is a GPLv3 macOS app for dictation and read-aloud, powered by three on-device AI models (speech-to-text, text-to-speech, and a small LLM). Based on VoiceInk."
     />
-    <meta property="og:title" content="Zerm - macOS voice dictation" />
+    <meta property="og:title" content="Zerm - on-device voice for macOS" />
     <meta
       property="og:description"
-      content="Tap a key, speak, and paste. Zerm is a GPLv3 macOS app based on VoiceInk by Beingpax."
+      content="Dictate and paste, or read any text aloud — on three on-device AI models, fast and private. GPLv3, based on VoiceInk by Beingpax."
     />
     <meta property="og:image" content="./icon.png" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -38,12 +38,14 @@
       <section class="hero">
         <div class="hero-copy">
           <img src="./icon.png" alt="Zerm app logo" class="hero-logo" />
-          <p class="kicker">GPLv3 macOS dictation</p>
-          <h1>Zerm turns speech into clean text on macOS.</h1>
+          <p class="kicker">GPLv3 · on-device voice for macOS</p>
+          <h1>Zerm turns speech into clean text — and reads it back.</h1>
           <p class="hero-lede">
-            Tap a hotkey, speak, and paste. Zerm is a native macOS dictation
-            app based on VoiceInk by Beingpax, adapted for Arcusis branding,
-            product direction, and ongoing GPLv3 development.
+            Tap a hotkey to dictate and paste, or select any text and have Zerm
+            read it aloud. It runs on three on-device AI models — speech-to-text,
+            text-to-speech, and a small agentic LLM — so the core experience is
+            fast, private, and works offline. Based on VoiceInk by Beingpax,
+            adapted for Arcusis under GPLv3.
           </p>
           <div class="hero-actions">
             <a id="primary-download" class="button primary" href="#download">


### PR DESCRIPTION
Documents the current product: three on-device AI models (Whisper STT, Kokoro TTS, Gemma LLM) plus Read Aloud and smart reading.

- **Notebook**: new notes with Mermaid diagrams — `Zerm Three Model Platform`, `Zerm Read Aloud`, `Zerm On-Device LLM`, `Zerm Smart Reading`; refreshed index + architecture (system overview diagram, updated state machine with speaking states).
- **README**: features rewritten around the three-model platform + link to the wiki.
- **GitHub Pages** (`docs/index.html`): hero, title, and metadata now cover dictation **and** read-aloud + on-device AI.

A companion **GitHub Wiki** (10 pages with diagrams) is staged; it needs a one-time web init before it can be pushed.