### PR TITLE
Don't surface task cancellation as a transcription failure

### DIFF
--- a/Zerm/Transcription/Engine/TranscriptionPipeline.swift
+++ b/Zerm/Transcription/Engine/TranscriptionPipeline.swift
@@ -158,6 +158,9 @@ class TranscriptionPipeline {
                     transcription.aiRequestUserMessage = enhancementService.lastUserMessageSent
                     finalPastedText = enhancedText
                 } catch {
+                    // A cancelled enhancement is not a failure — let it propagate to
+                    // the outer cancellation handler instead of relabelling it.
+                    if error is CancellationError { throw error }
                     let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
                     transcription.enhancedText = "Enhancement failed: \(errorDescription)"
                     let shortReason = String(errorDescription.prefix(80))
@@ -173,7 +176,28 @@ class TranscriptionPipeline {
 
             transcription.transcriptionStatus = TranscriptionStatus.completed.rawValue
 
+        } catch is CancellationError {
+            // The pipeline task was cancelled — e.g. a new recording started, the
+            // engine was torn down, or the user toggled again mid-transcription.
+            // This is normal control flow, NOT a failure: a raw CancellationError
+            // surfaces as the confusing "The operation couldn't be completed.
+            // (Swift.CancellationError error 1.)".  Discard the empty pending record
+            // and bail out quietly instead of writing a "Transcription Failed" entry.
+            logger.notice("⏹️ Transcription cancelled — discarding pending record")
+            modelContext.delete(transcription)
+            try? modelContext.save()
+            await onCleanup()
+            return
         } catch {
+            // A late/transitive cancellation can arrive wrapped or after the task is
+            // already cancelled; treat that as a cancel too rather than a hard failure.
+            if Task.isCancelled {
+                logger.notice("⏹️ Transcription cancelled (task) — discarding pending record")
+                modelContext.delete(transcription)
+                try? modelContext.save()
+                await onCleanup()
+                return
+            }
             let errorDescription = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             let recoverySuggestion = (error as? LocalizedError)?.recoverySuggestion ?? ""
             let fullErrorText = recoverySuggestion.isEmpty ? errorDescription : "\(errorDescription) \(recoverySuggestion)"


### PR DESCRIPTION
## Problem

Users frequently saw a transcription record reading:

> **Transcription Failed:** The operation couldn't be completed. (Swift.CancellationError error 1.)

That string is the `localizedDescription` of a raw `Swift.CancellationError`. It is **not** a real failure — it is what surfaces whenever the transcription pipeline's parent task is **cancelled** mid-flight, which happens routinely:

- the user toggles the hotkey again / starts a new recording,
- the engine is torn down,
- the 120s timeout `withThrowingTaskGroup` cancels its sibling task,
- a streaming session is cancelled.

The generic `catch` in `TranscriptionPipeline.run` treated this cancellation like any other error and persisted a "Transcription Failed" record, so cancellations showed up as scary failures in history "too often".

## Fix

Treat cancellation as normal control flow, not failure (`TranscriptionPipeline.swift`):

1. **Outer catch** — add an explicit `catch is CancellationError` (plus a `Task.isCancelled` guard in the generic catch for late/transitive cancellations). On cancel: log it, **delete the empty pending record**, release resources via `onCleanup()`, and return quietly. No "Transcription Failed" entry is written.
2. **Inner AI-enhancement catch** — re-throw `CancellationError` so it bubbles to the outer cancellation handler instead of being relabelled "Enhancement failed: …".

Genuine errors (model error, the explicit `TranscriptionTimeoutError`, etc.) still surface exactly as before.

## Verification

- `xcodebuild -scheme Zerm -configuration Debug build` → **BUILD SUCCEEDED**.