### PR TITLE
Add Developer ID + notarization release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,14 @@ name: Release
 # Native macOS release workflow.
 #
 # Current status: MANUAL
-#   DMG artifacts are built locally on a signed Apple Silicon Mac and uploaded
-#   to GitHub Releases with `gh release upload`. This is the documented process
-#   in BUILDING.md.
+#   DMG artifacts are built locally on the release Mac with `make release`
+#   (scripts/release.sh: Developer ID signing + notarization + stapling) and
+#   uploaded to GitHub Releases with `gh release upload`. See BUILDING.md
+#   "Building a Release".
 #
 # Future: automate with a self-hosted macOS runner or GitHub's macos-latest
-#   once a Developer ID certificate is available for hardened-runtime signing.
+#   (requires exporting the Developer ID certificate and notary API key as
+#   repository secrets).
 #
 # Windows / Linux: Zerm is a native macOS Swift app (AppKit + SwiftUI).
 #   There is no Windows or Linux build. The archived Tauri prototype that

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -35,6 +35,7 @@ make dev
 - `make setup` - Prepare the whisper framework for linking
 - `make build` - Build the Zerm Xcode project
 - `make local` - Build for local use (no Apple Developer certificate needed)
+- `make release` - Build the Developer ID signed + notarized release DMG (maintainers only)
 - `make run` - Launch the built Zerm app
 - `make dev` - Build and run (ideal for development workflow)
 - `make all` - Complete build process (default)
@@ -75,6 +76,42 @@ The `make local` command uses:
 - `LOCAL_BUILD` Swift compilation flag for conditional code paths
 
 Your normal `make all` / `make build` commands are completely unaffected.
+
+---
+
+## Building a Release (Maintainers)
+
+Public DMGs must be Developer ID signed **and notarized**, otherwise Gatekeeper
+rejects the app on other Macs ("Zerm is damaged and can't be opened" /
+"Apple could not verify Zerm is free of malware").
+
+Requirements on the release machine:
+
+- The `Developer ID Application: Arcusis LTD (F9Z784RA6D)` certificate in the login keychain
+- One-time notarization credential setup:
+
+```bash
+xcrun notarytool store-credentials zerm-notary \
+  --key ~/.appstoreconnect/private_keys/AuthKey_32D372QBLD.p8 \
+  --key-id 32D372QBLD \
+  --issuer <ISSUER-UUID>
+```
+
+The issuer UUID is shown in App Store Connect under
+**Users and Access → Integrations → App Store Connect API**.
+
+Then build the release:
+
+```bash
+make release            # or: scripts/release.sh
+```
+
+This builds the Release configuration, signs the app with Developer ID and the
+hardened runtime, notarizes app and DMG with Apple, staples the tickets, and
+verifies the result with `spctl`. The DMG lands in the repo root as
+`Zerm_X.Y.Z_aarch64.dmg`, ready for `gh release upload`.
+
+`SKIP_NOTARIZE=1 scripts/release.sh` does a signing-only dry run.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHERPA_XCFRAMEWORK := $(SHERPA_BUILD)/sherpa-onnx.xcframework
 ONNX_XCFRAMEWORK := $(SHERPA_BUILD)/onnxruntime.xcframework
 LOCAL_DERIVED_DATA := $(CURDIR)/.local-build
 
-.PHONY: all clean whisper sherpa setup build local check healthcheck help dev run install reset-permissions
+.PHONY: all clean whisper sherpa setup build local check healthcheck help dev run install reset-permissions release
 
 # Default target
 all: check build
@@ -121,6 +121,10 @@ install: local
 	@echo ""
 	@echo "Re-grant Accessibility and Screen Recording in Zerm → Permissions."
 
+# Build the Developer ID signed + notarized release DMG (see scripts/release.sh)
+release: check setup
+	@scripts/release.sh
+
 # Reset TCC permissions for Zerm (run after rebuilding with a new ad-hoc signature)
 reset-permissions:
 	@echo "Resetting Zerm TCC permissions..."
@@ -160,6 +164,7 @@ help:
 	@echo "  setup              Copy whisper XCFramework to Zerm project"
 	@echo "  build              Build the Zerm Xcode project"
 	@echo "  local              Build for local use (no Apple Developer certificate needed)"
+	@echo "  release            Build Developer ID signed + notarized release DMG"
 	@echo "  install            Build, install to /Applications, and reset Launchpad"
 	@echo "  reset-permissions  Reset Accessibility + Screen Recording TCC grants (run after rebuild)"
 	@echo "  run                Launch the built Zerm app"

--- a/Notebook/Zerm Known Follow Ups.md
+++ b/Notebook/Zerm Known Follow Ups.md
@@ -25,7 +25,7 @@ Open work tracked in `arcusis/Zerm` GitHub Issues. ~168 open as of 2026-05-22.
 ## Known Constraints
 
 - **Intel (x86_64) DMG** — not yet available. Only Apple Silicon build is published. Would need a CI self-hosted runner or Intel Mac.
-- **Developer ID signing** — Z#1 is open. All current releases are ad-hoc signed and require "allow anyway" in Gatekeeper.
+- **Developer ID signing** — Z#1. Releases through v2.1.3 were ad-hoc signed and rejected by Gatekeeper. Fixed by `make release` (see [[Zerm Release Signing]]); still blocked on the notary issuer UUID for the one-time `notarytool store-credentials` setup.
 - **macOS 26 compatibility** — `KeyboardShortcuts` package (2.4.0) uses Carbon `RegisterEventHotKey` which may have issues on macOS 26 with the "custom" hotkey option. The modifier-key path (NSEvent flagsChanged) is confirmed working.
 - **Ollama persistence** — Ollama must be manually started with `ollama serve` after reboot; not persisted as a login item.
 

--- a/Notebook/Zerm Production History.md
+++ b/Notebook/Zerm Production History.md
@@ -44,9 +44,9 @@
 
 ## Release Process
 
-1. Build locally: `xcodebuild -scheme Zerm ...` 
-2. Sign: Developer ID (or ad-hoc for internal builds)
-3. Create DMG, tag git: `git tag vX.Y.Z && git push origin vX.Y.Z`
+1. Bump `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` in the Xcode project
+2. `make release` — builds, Developer ID signs, notarizes, staples, creates the DMG (see [[Zerm Release Signing]])
+3. Tag git: `git tag vX.Y.Z && git push origin vX.Y.Z`
 4. Upload to GitHub Releases: `gh release create vX.Y.Z Zerm_X.Y.Z_aarch64.dmg`
 5. CI `release.yml` validates the tag and checks for DMG asset
 

--- a/Notebook/Zerm Release Signing.md
+++ b/Notebook/Zerm Release Signing.md
@@ -1,0 +1,20 @@
+# Zerm Release Signing
+
+Why users saw "Zerm is damaged and can't be opened": every public DMG through v2.1.3 was a `make local` Debug build — **ad-hoc signed** (`Signature=adhoc`, no team ID), never notarized. Gatekeeper rejects quarantined ad-hoc apps outright; since macOS 15 there is no right-click-Open bypass. Tracked as Z#1.
+
+## Trusted pipeline (added 2026-07-03)
+
+`make release` → `scripts/release.sh`:
+
+1. Builds **Release** config, arm64, with the `LOCAL_BUILD` flag and `Zerm.local.entitlements` — keeps runtime behavior identical to all previously shipped builds (CloudKit off, UserDefaults key store). The full `Zerm.entitlements` (CloudKit/aps/keychain-groups) are *restricted* entitlements that need a provisioning profile Developer ID signing alone cannot supply — the app would be killed at launch.
+2. Signs with `Developer ID Application: Arcusis LTD (F9Z784RA6D)` + hardened runtime + timestamp.
+3. Notarizes app and DMG via `notarytool` (keychain profile `zerm-notary`), staples both, verifies with `spctl`.
+
+## Credentials
+
+- Developer ID cert: in login keychain on the release Mac.
+- Notary API key: `~/.appstoreconnect/private_keys/AuthKey_32D372QBLD.p8`; the **issuer UUID** must be fetched from App Store Connect → Users and Access → Integrations, then stored once with `xcrun notarytool store-credentials zerm-notary ...` (exact command in `BUILDING.md`).
+- Note: project `DEVELOPMENT_TEAM` is `V6J6A3VWY2`, which does NOT match the Developer ID team `F9Z784RA6D` — the release script overrides the team on the command line; don't "fix" the project setting without checking dev-machine provisioning.
+- Sparkle EdDSA private key still missing (auto-update signing) — separate issue; `SUEnableAutomaticChecks=false` so releases work without it.
+
+Related: [[Zerm Known Follow Ups]], [[Zerm Production History]]

--- a/Notebook/_INDEX_Main.md
+++ b/Notebook/_INDEX_Main.md
@@ -17,6 +17,7 @@ This notebook captures durable project context for Zerm. Start here, then follow
 - [[Zerm Auto Stop Dictation]] — hands-free auto-stop + the self-cancellation gotcha
 - [[Zerm Setup And Permissions]]
 - [[Zerm Production History]]
+- [[Zerm Release Signing]] — Developer ID + notarization pipeline (fixes the Gatekeeper "damaged app" reports)
 - [[Zerm Known Follow Ups]]
 
 ## Current State (2026-06-21)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -euo pipefail
+
+# Builds the Developer ID signed + notarized DMG that gets uploaded to GitHub Releases.
+#
+# One-time setup — store notarization credentials in the login keychain:
+#   xcrun notarytool store-credentials zerm-notary \
+#     --key ~/.appstoreconnect/private_keys/AuthKey_32D372QBLD.p8 \
+#     --key-id 32D372QBLD \
+#     --issuer <ISSUER-UUID>
+#   (Issuer UUID: App Store Connect -> Users and Access -> Integrations -> App Store Connect API)
+#
+# Usage:
+#   scripts/release.sh                   # build + sign + notarize + staple
+#   SKIP_NOTARIZE=1 scripts/release.sh   # dry run: build + sign only
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Arcusis LTD (F9Z784RA6D)}"
+TEAM_ID="${TEAM_ID:-F9Z784RA6D}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-zerm-notary}"
+DERIVED_DATA="$REPO_ROOT/.release-build"
+WORK_DIR="$DERIVED_DATA/package"
+APP_PATH="$DERIVED_DATA/Build/Products/Release/Zerm.app"
+
+VERSION=$(sed -n 's/.*MARKETING_VERSION = \([0-9][0-9.]*\);.*/\1/p' "$REPO_ROOT/Zerm.xcodeproj/project.pbxproj" | head -1)
+DMG_NAME="Zerm_${VERSION}_aarch64.dmg"
+DMG_PATH="$REPO_ROOT/$DMG_NAME"
+
+echo "==> Releasing Zerm $VERSION"
+
+if [ "${SKIP_NOTARIZE:-0}" != "1" ]; then
+    if ! xcrun notarytool history --keychain-profile "$NOTARY_PROFILE" >/dev/null 2>&1; then
+        echo "error: notarytool credentials profile '$NOTARY_PROFILE' not found or invalid."
+        echo "Run the one-time setup documented at the top of this script."
+        exit 1
+    fi
+fi
+
+echo "==> Building Release configuration"
+rm -rf "$DERIVED_DATA"
+# LOCAL_BUILD keeps runtime behavior identical to previously shipped builds
+# (CloudKit off, UserDefaults key store) — the entitlements it requires need no
+# provisioning profile, which Developer ID signing alone cannot provide.
+xcodebuild -project "$REPO_ROOT/Zerm.xcodeproj" -scheme Zerm -configuration Release \
+    -derivedDataPath "$DERIVED_DATA" \
+    ARCHS=arm64 \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="$SIGN_IDENTITY" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    PROVISIONING_PROFILE_SPECIFIER= \
+    CODE_SIGN_ENTITLEMENTS="$REPO_ROOT/Zerm/Zerm.local.entitlements" \
+    CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+    OTHER_CODE_SIGN_FLAGS=--timestamp \
+    SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) LOCAL_BUILD' \
+    build
+
+[ -d "$APP_PATH" ] || { echo "error: $APP_PATH not found after build"; exit 1; }
+
+echo "==> Verifying code signature"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+if [ "${SKIP_NOTARIZE:-0}" != "1" ]; then
+    echo "==> Notarizing app"
+    mkdir -p "$WORK_DIR"
+    ditto -c -k --keepParent "$APP_PATH" "$WORK_DIR/Zerm.zip"
+    xcrun notarytool submit "$WORK_DIR/Zerm.zip" --keychain-profile "$NOTARY_PROFILE" --wait
+    xcrun stapler staple "$APP_PATH"
+fi
+
+echo "==> Creating DMG"
+STAGING="$WORK_DIR/dmg-staging"
+rm -rf "$STAGING" "$DMG_PATH"
+mkdir -p "$STAGING"
+ditto "$APP_PATH" "$STAGING/Zerm.app"
+ln -s /Applications "$STAGING/Applications"
+hdiutil create -volname "Zerm $VERSION" -srcfolder "$STAGING" -ov -format UDZO "$DMG_PATH"
+codesign --force --sign "$SIGN_IDENTITY" --timestamp "$DMG_PATH"
+
+if [ "${SKIP_NOTARIZE:-0}" != "1" ]; then
+    echo "==> Notarizing DMG"
+    xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+    xcrun stapler staple "$DMG_PATH"
+fi
+
+echo "==> Gatekeeper assessment"
+spctl -a -vv -t exec "$APP_PATH" || [ "${SKIP_NOTARIZE:-0}" = "1" ]
+spctl -a -vv -t open --context context:primary-signature "$DMG_PATH" || [ "${SKIP_NOTARIZE:-0}" = "1" ]
+
+echo ""
+echo "Done: $DMG_PATH"
+echo "Upload with: gh release upload v$VERSION $DMG_NAME"


### PR DESCRIPTION
## Problem

Users installing Zerm from GitHub Releases hit the Gatekeeper block dialog ("Zerm is damaged and can't be opened" / "Apple could not verify Zerm is free of malware"). Verified against the shipped v2.1.3 DMG: the app inside is an ad-hoc signed, un-notarized Debug build produced by `make local` — `spctl` rejects it outright, and macOS 15+ removed the right-click-Open bypass. Tracked as Z#1.

## Fix

New `scripts/release.sh` (wired up as `make release`):

- Builds the **Release** configuration (arm64), keeping the `LOCAL_BUILD` flag and unrestricted entitlements so runtime behavior stays identical to all previously shipped builds (the full entitlements need a provisioning profile that Developer ID signing cannot supply)
- Signs with `Developer ID Application: Arcusis LTD` + hardened runtime + secure timestamp, with `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` (the injected `get-task-allow` entitlement is rejected by the notary service)
- Notarizes the app and the DMG via `notarytool`, staples both tickets, verifies with `spctl`
- `SKIP_NOTARIZE=1` for signing-only dry runs

Verified end-to-end in dry-run mode: signature valid on all nested frameworks (Sparkle + XPC services, whisper, llama, MediaRemoteAdapter), no `get-task-allow`, Gatekeeper reports `Unnotarized Developer ID` — i.e. only the notarization submission remains, which the script performs once the one-time `notarytool store-credentials` setup (documented in BUILDING.md) is done.

Also updates BUILDING.md, the release.yml comments, and the notebook (new `Zerm Release Signing` note).

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XVzviQfDNf9WPehW5fFft1