### PR TITLE
Rotate Sparkle EdDSA public key for 2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ output/
 # Release build artifacts
 .release-build/
 *.dmg
+
+# Sparkle private keys (never commit)
+*.eddsa
+sparkle_eddsa_private.key

--- a/Zerm/Info.plist
+++ b/Zerm/Info.plist
@@ -7,7 +7,7 @@
 	<key>SUFeedURL</key>
 	<string>https://arcusis.github.io/Zerm/appcast.xml</string>
 	<key>SUPublicEDKey</key>
-	<string>rLRdZIjK3gHKfqNlAF9nT7FbjwSvwkJ8BVn0v2mD1Mo=</string>
+	<string>sVVWOPSnxppsLXs+3gzuMK0AeXyBdzS+uzDKnRQSWK0=</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>SUEnableAutomaticChecks</key>


### PR DESCRIPTION
## Summary
- Rotate `SUPublicEDKey` to the keypair now on the release machine keychain.
- Ignore Sparkle private key filenames in `.gitignore`.

Private key is **not** in the repo (`~/.zerm/sparkle_eddsa_private.key` + Keychain only).

Existing installs never had a working auto-update feed (stale unsigned 1.0.0 appcast), so this one-time rotation is required to enable Sparkle for 2.3.0+.

## Test plan
- [ ] release.sh signs appcast with matching private key
- [ ] 2.3.0 app embeds new public key