### PR TITLE
Enhancement: downloadable Gemma model list + Coding & Chat prompts

### DIFF
--- a/Zerm/LocalLLM/LocalLLMModelManager.swift
+++ b/Zerm/LocalLLM/LocalLLMModelManager.swift
@@ -1,44 +1,89 @@
 import Foundation
 import os
 
-/// Describes the downloadable on-device LLM (a single GGUF file).
-struct LocalLLMPackage {
+/// Describes a downloadable on-device LLM (a single GGUF file).
+struct LocalLLMPackage: Identifiable, Hashable {
     let fileName: String
     let displayName: String
     let approxSize: String
     let downloadURL: URL
+
+    /// `fileName` is the stable identity/key (also the on-disk name).
+    var id: String { fileName }
 }
 
-/// Downloads, stores, and serves Zerm's on-device language model — the third local model
-/// alongside Whisper (speech-to-text) and Kokoro (text-to-speech). Same UX as both: first
-/// use auto-downloads with a progress bar, then everything runs offline.
+/// Downloads, stores, and serves Zerm's on-device language models — the third local model
+/// alongside Whisper (speech-to-text) and Kokoro (text-to-speech). Same UX as both: pick a
+/// model, download it with a progress bar, then everything runs offline.
 ///
-/// Powers Read Aloud's "Natural reading" rewrite today; reusable for local AI Enhancement.
+/// A single "current" model is shared by AI Enhancement and Read Aloud's naturalization.
 @MainActor
 final class LocalLLMModelManager: ObservableObject {
     static let shared = LocalLLMModelManager()
 
-    /// Gemma 4 E2B Instruct, 4-bit (Q4_K_M) — the smallest/latest Gemma, on-device optimized
-    /// (Per-Layer Embeddings). The default "agentic" model powering both AI Enhancement and
-    /// Read Aloud naturalization. Users can swap in other GGUF models (see model management).
-    static let package = LocalLLMPackage(
-        fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
-        displayName: "Gemma 4 E2B (on-device)",
-        approxSize: "~3.1 GB",
-        downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf")!
-    )
+    /// The downloadable catalogue — all Google Gemma (GGUF, 4-bit Q4_K_M), spanning tiny→medium.
+    /// Users pick one as the active on-device model. Add new entries here to offer more.
+    static let packages: [LocalLLMPackage] = [
+        LocalLLMPackage(
+            fileName: "gemma-3-1b-it-Q4_K_M.gguf",
+            displayName: "Gemma 3 1B (on-device)",
+            approxSize: "~806 MB",
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf")!
+        ),
+        LocalLLMPackage(
+            fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+            displayName: "Gemma 4 E2B (on-device)",
+            approxSize: "~3.1 GB",
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf")!
+        ),
+        LocalLLMPackage(
+            fileName: "gemma-4-E4B-it-Q4_K_M.gguf",
+            displayName: "Gemma 4 E4B (on-device)",
+            approxSize: "~5.0 GB",
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf")!
+        ),
+        LocalLLMPackage(
+            fileName: "gemma-4-12b-it-Q4_K_M.gguf",
+            displayName: "Gemma 4 12B (on-device)",
+            approxSize: "~7.1 GB",
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q4_K_M.gguf")!
+        ),
+        LocalLLMPackage(
+            fileName: "gemma-3-27b-it-Q4_K_M.gguf",
+            displayName: "Gemma 3 27B (on-device)",
+            approxSize: "~16.5 GB",
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-27b-it-GGUF/resolve/main/gemma-3-27b-it-Q4_K_M.gguf")!
+        )
+    ]
 
-    @Published private(set) var isInstalled = false
-    @Published private(set) var isDownloading = false
-    /// 0.0–1.0 while downloading; nil when idle.
-    @Published private(set) var downloadProgress: Double?
+    /// The shipped default (out-of-box) model.
+    static let defaultPackage = packages.first { $0.fileName == "gemma-4-E2B-it-Q4_K_M.gguf" } ?? packages[1]
+
+    private static let currentModelKey = "CurrentLocalLLMModel"
+
+    /// The currently-selected on-device model (shared by Enhancement + Read Aloud).
+    nonisolated static var current: LocalLLMPackage {
+        let saved = UserDefaults.standard.string(forKey: currentModelKey)
+        return packages.first { $0.fileName == saved } ?? defaultPackage
+    }
+
+    /// Backward-compatible alias for the many call sites that referenced the single package;
+    /// it now resolves to the currently-selected model.
+    nonisolated static var package: LocalLLMPackage { current }
+
+    @Published private(set) var installedFiles: Set<String> = []
+    /// Per-model download progress (0.0–1.0), keyed by fileName; absent when not downloading.
+    @Published private(set) var downloadProgress: [String: Double] = [:]
+    /// Mirrors the persisted current-model selection so SwiftUI updates on change.
+    @Published private(set) var currentFileName: String = LocalLLMModelManager.current.fileName
     @Published private(set) var statusText: String?
 
     let modelsDirectory: URL
     private let logger = Logger(subsystem: "com.arcusis.zerm", category: "LocalLLMModelManager")
     private var engine: LlamaEngine?
-    private var downloadTask: URLSessionDownloadTask?
-    private var progressObservation: NSKeyValueObservation?
+    private var engineFileName: String?
+    private var downloadTasks: [String: URLSessionDownloadTask] = [:]
+    private var progressObservations: [String: NSKeyValueObservation] = [:]
 
     private init() {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -48,38 +93,66 @@ final class LocalLLMModelManager: ObservableObject {
         refreshInstalled()
     }
 
-    // MARK: - Paths
+    // MARK: - Paths & state
 
-    var modelPath: URL { modelsDirectory.appendingPathComponent(Self.package.fileName) }
+    func path(for package: LocalLLMPackage) -> URL { modelsDirectory.appendingPathComponent(package.fileName) }
+
+    var currentPackage: LocalLLMPackage { Self.current }
+
+    /// Path of the currently-selected model (kept for backward compatibility).
+    var modelPath: URL { path(for: currentPackage) }
 
     func refreshInstalled() {
-        isInstalled = FileManager.default.fileExists(atPath: modelPath.path)
+        var set = Set<String>()
+        for package in Self.packages where FileManager.default.fileExists(atPath: path(for: package).path) {
+            set.insert(package.fileName)
+        }
+        installedFiles = set
     }
 
-    /// Thread-safe install check usable from non-main contexts (e.g. `AIService`).
+    func isDownloaded(_ package: LocalLLMPackage) -> Bool { installedFiles.contains(package.fileName) }
+    func isDownloading(_ package: LocalLLMPackage) -> Bool { downloadProgress[package.fileName] != nil }
+
+    /// True when the *current* model is downloaded (backward-compatible single-model check).
+    var isInstalled: Bool { isDownloaded(currentPackage) }
+
+    /// Thread-safe install check for the current model, usable from non-main contexts (e.g. `AIService`).
     nonisolated static var isModelDownloaded: Bool {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("com.arcusis.zerm")
         let path = appSupport.appendingPathComponent("LLMModels")
-            .appendingPathComponent(package.fileName).path
+            .appendingPathComponent(current.fileName).path
         return FileManager.default.fileExists(atPath: path)
+    }
+
+    // MARK: - Selection
+
+    /// Switch the active on-device model. Unloads the previous engine so the next generation
+    /// loads the newly-selected weights.
+    func select(_ package: LocalLLMPackage) {
+        guard package.fileName != currentFileName else { return }
+        UserDefaults.standard.set(package.fileName, forKey: Self.currentModelKey)
+        currentFileName = package.fileName
+        if engineFileName != package.fileName {
+            engine = nil
+            engineFileName = nil
+        }
     }
 
     // MARK: - Download
 
-    func download() async {
-        guard !isDownloading else { return }
-        isDownloading = true
-        downloadProgress = 0
-        statusText = "Downloading reading model…"
-        defer { isDownloading = false; downloadProgress = nil }
+    func download(_ package: LocalLLMPackage) async {
+        guard downloadProgress[package.fileName] == nil else { return }
+        downloadProgress[package.fileName] = 0
+        statusText = nil
+        defer { downloadProgress[package.fileName] = nil }
 
         do {
-            let file = try await downloadFile(from: Self.package.downloadURL)
-            try? FileManager.default.removeItem(at: modelPath)
-            try FileManager.default.moveItem(at: file, to: modelPath)
+            let file = try await downloadFile(for: package)
+            let dest = path(for: package)
+            try? FileManager.default.removeItem(at: dest)
+            try FileManager.default.moveItem(at: file, to: dest)
             refreshInstalled()
-            statusText = isInstalled ? nil : "Download incomplete"
         } catch is CancellationError {
             statusText = "Download cancelled"
         } catch {
@@ -88,30 +161,40 @@ final class LocalLLMModelManager: ObservableObject {
         }
     }
 
-    func cancelDownload() {
-        downloadTask?.cancel()
-        downloadTask = nil
+    /// Downloads the current model (backward-compatible no-arg form).
+    func download() async { await download(currentPackage) }
+
+    func cancelDownload(_ package: LocalLLMPackage) {
+        downloadTasks[package.fileName]?.cancel()
+        downloadTasks[package.fileName] = nil
     }
 
-    func delete() {
-        engine = nil
-        try? FileManager.default.removeItem(at: modelPath)
+    func delete(_ package: LocalLLMPackage) {
+        if engineFileName == package.fileName { engine = nil; engineFileName = nil }
+        try? FileManager.default.removeItem(at: path(for: package))
         refreshInstalled()
     }
 
-    /// Release the warm Gemma engine so it doesn't pin ~2–3 GB after idle.
+    /// Deletes the current model (backward-compatible no-arg form).
+    func delete() { delete(currentPackage) }
+
+    /// Release the warm engine so it doesn't pin GB of RAM after idle.
     func unloadIfIdle() {
         guard engine != nil else { return }
         logger.notice("Unloading local LLM engine (idle / memory reclaim)")
         engine = nil
+        engineFileName = nil
     }
 
     /// Downloads to a temp file, reporting fractional progress via KVO (mirrors KokoroModelManager).
-    private func downloadFile(from url: URL) async throws -> URL {
+    private func downloadFile(for package: LocalLLMPackage) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            let task = URLSession.shared.downloadTask(with: url) { [weak self] tempURL, response, error in
-                self?.progressObservation?.invalidate()
-                self?.progressObservation = nil
+            let task = URLSession.shared.downloadTask(with: package.downloadURL) { [weak self] tempURL, response, error in
+                Task { @MainActor [weak self] in
+                    self?.progressObservations[package.fileName]?.invalidate()
+                    self?.progressObservations[package.fileName] = nil
+                    self?.downloadTasks[package.fileName] = nil
+                }
                 if let error { continuation.resume(throwing: error); return }
                 guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
                     continuation.resume(throwing: TTSError.http((response as? HTTPURLResponse)?.statusCode ?? -1, "download failed"))
@@ -120,7 +203,7 @@ final class LocalLLMModelManager: ObservableObject {
                 guard let tempURL else { continuation.resume(throwing: TTSError.badResponse); return }
                 do {
                     let dest = URL(fileURLWithPath: NSTemporaryDirectory())
-                        .appendingPathComponent("llm-download-\(Self.package.fileName)")
+                        .appendingPathComponent("llm-download-\(package.fileName)")
                     try? FileManager.default.removeItem(at: dest)
                     try FileManager.default.moveItem(at: tempURL, to: dest)
                     continuation.resume(returning: dest)
@@ -128,9 +211,9 @@ final class LocalLLMModelManager: ObservableObject {
                     continuation.resume(throwing: error)
                 }
             }
-            self.downloadTask = task
-            self.progressObservation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
-                Task { @MainActor in self?.downloadProgress = progress.fractionCompleted }
+            self.downloadTasks[package.fileName] = task
+            self.progressObservations[package.fileName] = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+                Task { @MainActor in self?.downloadProgress[package.fileName] = progress.fractionCompleted }
             }
             task.resume()
         }
@@ -138,17 +221,17 @@ final class LocalLLMModelManager: ObservableObject {
 
     // MARK: - Generation
 
-    /// Rewrites/answers using the on-device model. Loads it on first use.
+    /// Rewrites/answers using the current on-device model. Loads it on first use.
     func generate(system: String, user: String, maxNewTokens: Int = 400,
                   isCancelled: @escaping @Sendable () -> Bool = { false }) async throws -> String {
         guard isInstalled else {
-            throw TTSError.notAvailable("The on-device reading model isn't downloaded yet. Download it in Read Aloud settings.")
+            throw TTSError.notAvailable("The on-device model isn't downloaded yet. Download it in Enhancement or Read Aloud settings.")
         }
         let engine = ensureEngine()
         return try await engine.generate(system: system, user: user, maxNewTokens: maxNewTokens, isCancelled: isCancelled)
     }
 
-    /// Pre-loads the model in the background so the first natural read is fast.
+    /// Pre-loads the current model in the background so the first natural read is fast.
     func prewarmIfNeeded() async {
         guard isInstalled, TTSSettings.naturalReadingAI else { return }
         let engine = ensureEngine()
@@ -156,9 +239,10 @@ final class LocalLLMModelManager: ObservableObject {
     }
 
     private func ensureEngine() -> LlamaEngine {
-        if let engine { return engine }
+        if let engine, engineFileName == currentPackage.fileName { return engine }
         let engine = LlamaEngine(modelPath: modelPath.path)
         self.engine = engine
+        self.engineFileName = currentPackage.fileName
         return engine
     }
 }

--- a/Zerm/Models/PredefinedPrompts.swift
+++ b/Zerm/Models/PredefinedPrompts.swift
@@ -7,6 +7,8 @@ enum PredefinedPrompts {
     // Static UUIDs for predefined prompts
     static let defaultPromptId = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
     static let assistantPromptId = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+    static let codingPromptId = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+    static let chatPromptId = UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
     
     static var all: [CustomPrompt] {
         // Always return the latest predefined prompts from source code
@@ -33,6 +35,26 @@ enum PredefinedPrompts {
                 description: "AI assistant that provides direct answers to queries",
                 isPredefined: true,
                 useSystemInstructions: false
+            ),
+
+            CustomPrompt(
+                id: codingPromptId,
+                title: "Coding",
+                promptText: PromptTemplates.all.first { $0.title == "Coding" }?.promptText ?? "",
+                icon: "curlybraces",
+                description: "Cleans dictated code and technical talk without writing or answering",
+                isPredefined: true,
+                useSystemInstructions: true
+            ),
+
+            CustomPrompt(
+                id: chatPromptId,
+                title: "Chat",
+                promptText: PromptTemplates.all.first { $0.title == "Chat" }?.promptText ?? "",
+                icon: "message.fill",
+                description: "Casual chat-style formatting for messages",
+                isPredefined: true,
+                useSystemInstructions: true
             )
         ]
     }

--- a/Zerm/Models/PromptTemplates.swift
+++ b/Zerm/Models/PromptTemplates.swift
@@ -51,19 +51,41 @@ enum PromptTemplates {
                 id: UUID(),
                 title: "Chat",
                 promptText: """
-                    - Rewrite the <TRANSCRIPT> text as a chat message: informal, concise, and conversational.
-                    - Keep emotive markers and emojis if present; don't invent new ones.
-                    - Lightly fix grammar, remove fillers and repeated words, and improve flow without changing meaning.
-                    - Keep the original tone; only be professional if the <TRANSCRIPT> already is.
-                    - Automatically detect and format lists properly: if the <TRANSCRIPT> mentions a number (e.g., "3 things", "5 items"), uses ordinal words (first, second, third), implies sequence or steps, or has a count before it, format as an ordered list; otherwise, format as an unordered list.
-                    - Write numbers as numerals (e.g., 'five' → '5', 'twenty dollars' → '$20').
-                    - Format like a modern chat message - short lines, natural breaks, emoji-friendly.
+                    - Rewrite the <TRANSCRIPT> text as a casual chat message (texts, Slack, DMs): informal, concise, and conversational. Never answer questions or reply to it — only clean up what was said.
+                    - Keep the speaker's own voice; do not formalize it or make it sound like an email.
+                    - Remove fillers and false starts; on self-corrections ("wait no", "I mean", "scratch that") keep only the corrected version.
+                    - Fix obvious grammar and spelling, but keep contractions, slang, and casual phrasing (gonna, yeah, tbh, lol).
+                    - Use light punctuation only, just enough to read easily; no semicolons or formal structure. Break into short lines where the speaker pauses.
+                    - Write numbers as numerals; keep names, @mentions, links, and any emojis that were said. Don't invent new emojis.
                     - Do not add greetings, sign-offs, or commentary.
                     - Output only the chat message.
                     - Don't add any information not available in the <TRANSCRIPT> text ever.
                     """,
-                icon: "bubble.left.and.bubble.right.fill",
+                icon: "message.fill",
                 description: "Casual chat-style formatting"
+            ),
+
+            TemplatePrompt(
+                id: UUID(),
+                title: "Coding",
+                promptText: """
+                    - Clean the <TRANSCRIPT> text as dictated code and technical talk into clean written text. You are transcribing what was said — NOT writing, completing, fixing, or reviewing code, and NOT answering technical questions.
+                    - Fix grammar, punctuation, and capitalization; remove fillers and false starts; on self-corrections ("scratch that", "I mean", "wait no") keep only the corrected version.
+                    - Convert operators and symbols spoken aloud into the symbol when clearly meant as code: "equals equals" ==, "triple equals" ===, "not equals" !=, "greater than or equal" >=, "arrow" ->, "fat arrow" =>, "plus plus" ++, "open paren" (, "close paren" ), "open brace" {, "close brace" }, "open bracket" [, "close bracket" ], "dot" ., "colon" :, "semicolon" ;, "dash dash" --, "hash" #, "at sign" @, "dollar sign" $, "pipe" |, "star" *, "underscore" _, "slash" /, "backslash" \\.
+                    - When the speaker frames a name ("a function called…", "a variable named…", "the class…"), render it as one identifier in the stated case (camelCase, snake_case, PascalCase, kebab-case, ALL_CAPS). If no case is stated, default to camelCase for functions and variables, PascalCase for classes and types.
+                    - Fix clear technical mis-hearings: "four loop" → for loop, "num pie" → numpy, "get hub" → GitHub, "sequel" → SQL, "jason" → JSON, "no sequel" → NoSQL, "pie torch" → PyTorch, "yamel" → YAML, "en pm" → npm, "reg ex" → regex, "dot pie" → .py. Preserve real file paths, CLI flags, and commands exactly (e.g. "dash dash verbose" → --verbose).
+                    - Wrap identifiers, symbols, commands, and file paths in inline `backticks`. Use a fenced code block only if the speaker clearly dictated a multi-line snippet or said "code block"; keep explanations as plain prose.
+                    - Never invent names, values, syntax, brackets, or logic the speaker did not say. Never fix or improve the code's logic, even if it is wrong. If a word is ambiguous between plain English and a code symbol, keep the plain word.
+                    - Examples (input → output):
+                      - "so the bug is in the for loop it's off by one because I wrote less than equal instead of less than" → "So the bug is in the `for` loop — it's off by one because I wrote `<=` instead of `<`."
+                      - "define a function called get user by id that takes a user id and returns a user" → "Define a function called `getUserById` that takes a `userId` and returns a user."
+                      - "import num pie as np then read the jason file with pandas and push it to get hub" → "Import `numpy` as `np`, then read the JSON file with `pandas` and push it to GitHub."
+                      - "how do I center a div in css can you write the flexbox for me" → "How do I center a div in CSS? Can you write the flexbox for me?"
+                    - Output only the cleaned text.
+                    - Don't add any information not available in the <TRANSCRIPT> text ever.
+                    """,
+                icon: "curlybraces",
+                description: "Cleans dictated code and technical talk"
             ),
             
             TemplatePrompt(

--- a/Zerm/Views/AI Models/APIKeyManagementView.swift
+++ b/Zerm/Views/AI Models/APIKeyManagementView.swift
@@ -284,7 +284,7 @@ struct APIKeyManagementView: View {
                     Text("Runs entirely on your Mac — no API key, nothing leaves the device. Used to clean up dictation and to make Read Aloud sound natural.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    LocalLLMModelCardView()
+                    LocalLLMModelListView()
 
                 } else {
                     if aiService.isAPIKeyValid {

--- a/Zerm/Views/AI Models/LocalLLMModelCardView.swift
+++ b/Zerm/Views/AI Models/LocalLLMModelCardView.swift
@@ -1,65 +1,94 @@
 import SwiftUI
 
-/// Reusable management card for Zerm's on-device language model (Gemma). Mirrors the voice
-/// model cards: shows size, a one-tap download with progress, installed state, and delete.
-/// Shared by the AI Models / Enhancement screen and Read Aloud settings so model management
-/// looks and behaves the same everywhere.
+/// The full list of downloadable on-device models. Shared by the AI Enhancement screen and
+/// Read Aloud settings so on-device model management looks and behaves the same everywhere.
+struct LocalLLMModelListView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(LocalLLMModelManager.packages) { package in
+                LocalLLMModelCardView(package: package)
+            }
+        }
+    }
+}
+
+/// Management card for a single on-device language model (Gemma). Mirrors the voice/speech
+/// model cards: shows size, one-tap download with progress, installed state, delete, and which
+/// model is currently in use.
 struct LocalLLMModelCardView: View {
+    let package: LocalLLMPackage
     @ObservedObject private var manager = LocalLLMModelManager.shared
 
+    private var isCurrent: Bool { manager.currentFileName == package.fileName }
+    private var isDownloaded: Bool { manager.isDownloaded(package) }
+    private var progress: Double? { manager.downloadProgress[package.fileName] }
+
     var body: some View {
-        let pkg = LocalLLMModelManager.package
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Image(systemName: "brain")
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(pkg.displayName).font(.subheadline.weight(.medium))
-                    Text("Private, on-device. No API key. Recommended.")
+                    Text(package.displayName).font(.subheadline.weight(.medium))
+                    Text("Private, on-device. No API key.")
                         .font(.caption2).foregroundStyle(.secondary)
                 }
                 Spacer()
-                Text(pkg.approxSize).font(.caption).foregroundStyle(.secondary)
+                if isCurrent {
+                    Label("In use", systemImage: "checkmark.circle.fill")
+                        .font(.caption2).foregroundStyle(.green)
+                }
+                Text(package.approxSize).font(.caption).foregroundStyle(.secondary)
             }
 
-            if manager.isInstalled {
+            if isDownloaded {
                 HStack {
                     Label("Downloaded — runs fully offline", systemImage: "checkmark.circle.fill")
                         .font(.caption).foregroundStyle(.green)
                     Spacer()
-                    Button(role: .destructive) { manager.delete() } label: {
+                    if !isCurrent {
+                        Button("Use this model") { manager.select(package) }
+                            .controlSize(.small)
+                    }
+                    Button(role: .destructive) { manager.delete(package) } label: {
                         Label("Delete", systemImage: "trash")
                     }
                     .controlSize(.small)
                 }
-            } else if manager.isDownloading {
+            } else if progress != nil {
                 VStack(alignment: .leading, spacing: 6) {
-                    ProgressView(value: manager.downloadProgress ?? 0)
+                    ProgressView(value: progress ?? 0)
                     HStack {
-                        Text(manager.statusText ?? "Downloading…")
-                            .font(.caption).foregroundStyle(.secondary)
+                        Text("Downloading…").font(.caption).foregroundStyle(.secondary)
                         Spacer()
-                        if let p = manager.downloadProgress {
+                        if let p = progress {
                             Text("\(Int(p * 100))%").font(.caption.monospacedDigit())
                         }
-                        Button("Cancel") { manager.cancelDownload() }.controlSize(.small)
+                        Button("Cancel") { manager.cancelDownload(package) }.controlSize(.small)
                     }
                 }
             } else {
                 HStack {
-                    Text("Download once to enable on-device AI. No API key needed.")
+                    Text("Download once to use on-device. No API key needed.")
                         .font(.caption).foregroundStyle(.secondary)
                     Spacer()
-                    Button { Task { await manager.download() } } label: {
-                        Label("Download model", systemImage: "arrow.down.circle")
+                    Button {
+                        manager.select(package)
+                        Task { await manager.download(package) }
+                    } label: {
+                        Label("Download", systemImage: "arrow.down.circle")
                     }
                     .controlSize(.small)
-                }
-                if let status = manager.statusText {
-                    Text(status).font(.caption).foregroundStyle(.red)
                 }
             }
         }
         .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color.primary.opacity(0.04)))
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.primary.opacity(isCurrent ? 0.07 : 0.04))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(isCurrent ? Color.accentColor.opacity(0.5) : .clear, lineWidth: 1)
+        )
     }
 }

--- a/Zerm/Views/Settings/TextToSpeechSettingsView.swift
+++ b/Zerm/Views/Settings/TextToSpeechSettingsView.swift
@@ -190,7 +190,7 @@ struct TextToSpeechSettingsView: View {
                         .font(.caption).foregroundStyle(.secondary)
                 }
 
-                LocalLLMModelCardView()
+                LocalLLMModelListView()
             }
             .padding(8)
         }


### PR DESCRIPTION
Improves the Enhancement tab — the heart of Zerm — in two ways.

## 1. Downloadable enhancement models
The on-device LLM was a single hardcoded package (Gemma 4 E2B). This turns it into a **registry of five Google Gemma models**, mirroring the Whisper transcription-model pattern (per-model download/delete/progress + one shared "current" model):

| Model | Size | |
|---|---|---|
| Gemma 3 1B | ~806 MB | tiny/fastest |
| **Gemma 4 E2B** | ~3.1 GB | shipped default (kept) |
| Gemma 4 E4B | ~5.0 GB | safer small |
| Gemma 4 12B | ~7.1 GB | medium sweet spot |
| Gemma 3 27B | ~16.5 GB | ceiling (~27B) |

**All Google Gemma** by design: satisfies "American models, no Chinese", and keeps the llama.cpp bridge's Gemma-format stop tokens correct (Phi/Llama would need a bridge change; Mistral is French; Qwen/DeepSeek are excluded). The current model is shared by AI Enhancement and Read Aloud naturalization. Existing single-model call sites keep working — they now resolve to the selected model, so `AIService` needed no changes.

## 2. Coding & Chat prompts
Two new predefined prompts, both cleaners that reuse the existing anti-chatbot wrapper. The research focus was the #1 failure mode: the model *answering* dictated questions instead of *cleaning* them.

- **Coding**: converts spoken operators (`"equals equals"`→`==`), renders identifiers in the stated case, fixes technical homophones (`num pie`→`numpy`, `jason`→`JSON`), wraps code in backticks — and **never writes, completes, fixes, or answers**. Ships with few-shot examples (the "clean the question, don't answer it" and "don't fix the bug" cases) because small on-device models need examples to hold that line.
- **Chat**: casual messaging tone, keeps the speaker's voice, never replies.

Both auto-seed for existing users (new fixed UUIDs) and render automatically in the prompt grid — no UI or migration changes.

## Verification
- Build green (Debug).
- **Not runtime-screenshotted**: Debug builds are ad-hoc signed and can't dyld-load the Developer-ID frameworks on Apple Silicon (a build-artifact signing mismatch, documented — not a code issue). No crashes. A proper signed local build (or the user trying it) is the way to see the UI live.
- `ZermTests` module-resolution failure is pre-existing on Production, unrelated.