### PR TITLE
Hardware-aware model recommendations and install gating

### DIFF
--- a/Zerm/LocalLLM/LocalLLMModelManager.swift
+++ b/Zerm/LocalLLM/LocalLLMModelManager.swift
@@ -6,6 +6,8 @@ struct LocalLLMPackage: Identifiable, Hashable {
     let fileName: String
     let displayName: String
     let approxSize: String
+    /// Rough peak RAM (GB) while generating: weights + KV cache + runtime overhead.
+    let estimatedRAMGB: Double
     let downloadURL: URL
 
     /// `fileName` is the stable identity/key (also the on-disk name).
@@ -28,30 +30,35 @@ final class LocalLLMModelManager: ObservableObject {
             fileName: "gemma-3-1b-it-Q4_K_M.gguf",
             displayName: "Gemma 3 1B (on-device)",
             approxSize: "~806 MB",
+            estimatedRAMGB: 1.5,
             downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf")!
         ),
         LocalLLMPackage(
             fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
             displayName: "Gemma 4 E2B (on-device)",
             approxSize: "~3.1 GB",
+            estimatedRAMGB: 4.0,
             downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf")!
         ),
         LocalLLMPackage(
             fileName: "gemma-4-E4B-it-Q4_K_M.gguf",
             displayName: "Gemma 4 E4B (on-device)",
             approxSize: "~5.0 GB",
+            estimatedRAMGB: 6.0,
             downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf")!
         ),
         LocalLLMPackage(
             fileName: "gemma-4-12b-it-Q4_K_M.gguf",
             displayName: "Gemma 4 12B (on-device)",
             approxSize: "~7.1 GB",
+            estimatedRAMGB: 9.0,
             downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q4_K_M.gguf")!
         ),
         LocalLLMPackage(
             fileName: "gemma-3-27b-it-Q4_K_M.gguf",
             displayName: "Gemma 3 27B (on-device)",
             approxSize: "~16.5 GB",
+            estimatedRAMGB: 19.0,
             downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-27b-it-GGUF/resolve/main/gemma-3-27b-it-Q4_K_M.gguf")!
         )
     ]
@@ -142,6 +149,10 @@ final class LocalLLMModelManager: ObservableObject {
     // MARK: - Download
 
     func download(_ package: LocalLLMPackage) async {
+        guard !package.hardwareFit.blocksInstall else {
+            statusText = "\(package.displayName) needs more memory than this Mac has available"
+            return
+        }
         guard downloadProgress[package.fileName] == nil else { return }
         downloadProgress[package.fileName] = 0
         statusText = nil

--- a/Zerm/Services/HardwareCapability.swift
+++ b/Zerm/Services/HardwareCapability.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Rates this Mac's ability to run local models and judges whether a given model
+/// is a good fit, a stretch, or too heavy to install at all.
+enum HardwareCapability {
+
+    enum Tier {
+        /// Intel Macs and Apple Silicon with 8 GB RAM.
+        case limited
+        /// Apple Silicon with 16 GB RAM.
+        case capable
+        /// Apple Silicon with 24 GB RAM or more.
+        case powerful
+    }
+
+    static let physicalMemoryGB: Double =
+        Double(ProcessInfo.processInfo.physicalMemory) / 1_073_741_824
+
+    static let chipName: String = {
+        var size = 0
+        sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
+        var chars = [CChar](repeating: 0, count: size)
+        sysctlbyname("machdep.cpu.brand_string", &chars, &size, nil, 0)
+        let name = String(cString: chars)
+        return name.isEmpty ? SystemArchitecture.current : name
+    }()
+
+    static let tier: Tier = {
+        if SystemArchitecture.isIntelMac { return .limited }
+        switch physicalMemoryGB {
+        case ..<12: return .limited
+        case ..<24: return .capable
+        default: return .powerful
+        }
+    }()
+
+    /// Human-readable summary, e.g. "Apple M1 · 8 GB RAM".
+    static var summary: String {
+        "\(chipName) · \(Int(physicalMemoryGB.rounded())) GB RAM"
+    }
+
+    // MARK: - Per-model fit
+
+    enum ModelFit {
+        /// Runs comfortably on this Mac.
+        case good
+        /// Will run, but may be slow and starve other apps of memory — warn before install.
+        case heavy(reason: String)
+        /// Needs more memory than this Mac can spare — installation is blocked.
+        case tooHeavy(reason: String)
+
+        var blocksInstall: Bool {
+            if case .tooHeavy = self { return true }
+            return false
+        }
+    }
+
+    /// Judges a model by the peak RAM it needs while running, against the memory this
+    /// Mac can realistically spare (the OS and other apps need the rest).
+    static func fit(forEstimatedRAMGB needed: Double) -> ModelFit {
+        fit(forEstimatedRAMGB: needed, physicalMemoryGB: physicalMemoryGB)
+    }
+
+    /// Testable core: thresholds are fractions of installed RAM.
+    static func fit(forEstimatedRAMGB needed: Double, physicalMemoryGB total: Double) -> ModelFit {
+        let neededText = String(format: "%.1f", needed)
+        if needed > total * 0.70 {
+            return .tooHeavy(reason: "Needs ~\(neededText) GB of memory — more than this Mac (\(Int(total.rounded())) GB) can spare while macOS is running.")
+        }
+        if needed > total * 0.45 {
+            return .heavy(reason: "Needs ~\(neededText) GB of memory — will run, but expect slowdowns on this Mac (\(Int(total.rounded())) GB).")
+        }
+        return .good
+    }
+
+    /// Transcription model names recommended for this Mac, in display order.
+    static var recommendedTranscriptionModelNames: [String] {
+        switch tier {
+        case .limited:
+            return ["ggml-base.en", "parakeet-tdt-0.6b-v2", "whisper-large-v3-turbo"]
+        case .capable, .powerful:
+            return ["ggml-base.en", "parakeet-tdt-0.6b-v2", "ggml-large-v3-turbo-q5_0", "whisper-large-v3-turbo"]
+        }
+    }
+}
+
+// MARK: - Model RAM estimates
+
+extension WhisperModel {
+    /// Rough peak working-set while transcribing: the catalog's relative `ramUsage`
+    /// (0.3 tiny … 1.8 large-turbo) scaled to gigabytes.
+    var estimatedRAMGB: Double { ramUsage * 2.0 }
+
+    var hardwareFit: HardwareCapability.ModelFit {
+        HardwareCapability.fit(forEstimatedRAMGB: estimatedRAMGB)
+    }
+}
+
+extension FluidAudioModel {
+    var estimatedRAMGB: Double { ramUsage * 2.0 }
+
+    var hardwareFit: HardwareCapability.ModelFit {
+        HardwareCapability.fit(forEstimatedRAMGB: estimatedRAMGB)
+    }
+}
+
+extension LocalLLMPackage {
+    var hardwareFit: HardwareCapability.ModelFit {
+        HardwareCapability.fit(forEstimatedRAMGB: estimatedRAMGB)
+    }
+}

--- a/Zerm/Transcription/FluidAudio/FluidAudioModelManager.swift
+++ b/Zerm/Transcription/FluidAudio/FluidAudioModelManager.swift
@@ -42,7 +42,7 @@ class FluidAudioModelManager: ObservableObject {
     // MARK: - Download
 
     func downloadFluidAudioModel(_ model: FluidAudioModel) async {
-        if isFluidAudioModelDownloaded(model) {
+        if isFluidAudioModelDownloaded(model) || model.hardwareFit.blocksInstall {
             return
         }
 

--- a/Zerm/Transcription/Whisper/WhisperModelManager.swift
+++ b/Zerm/Transcription/Whisper/WhisperModelManager.swift
@@ -193,6 +193,7 @@ class WhisperModelManager: ObservableObject {
     }
 
     func downloadModel(_ model: WhisperModel) async {
+        guard !model.hardwareFit.blocksInstall else { return }
         guard let url = URL(string: model.downloadURL) else { return }
         await performModelDownload(model, url)
     }

--- a/Zerm/Views/AI Models/FluidAudioModelCardView.swift
+++ b/Zerm/Views/AI Models/FluidAudioModelCardView.swift
@@ -38,6 +38,9 @@ struct FluidAudioModelCardView: View {
                 headerSection
                 metadataSection
                 descriptionSection
+                if !isDownloaded {
+                    HardwareFitNotice(fit: model.hardwareFit)
+                }
                 progressSection
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -128,6 +131,14 @@ struct FluidAudioModelCardView: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+            } else if model.hardwareFit.blocksInstall {
+                Text("Unavailable")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(Color(.tertiaryLabelColor))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(Color(.quaternaryLabelColor).opacity(0.3)))
+                    .help("This model needs more memory than this Mac has available")
             } else {
                 Button(action: {
                     Task {

--- a/Zerm/Views/AI Models/HardwareFitViews.swift
+++ b/Zerm/Views/AI Models/HardwareFitViews.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Inline warning shown on a model card when the model is a stretch (orange) or
+/// too heavy to install (red) for this Mac.
+struct HardwareFitNotice: View {
+    let fit: HardwareCapability.ModelFit
+
+    var body: some View {
+        switch fit {
+        case .good:
+            EmptyView()
+        case .heavy(let reason):
+            notice(icon: "exclamationmark.triangle.fill", color: .orange,
+                   title: "Heavy for this Mac", detail: reason)
+        case .tooHeavy(let reason):
+            notice(icon: "xmark.octagon.fill", color: .red,
+                   title: "Not supported on this Mac", detail: reason)
+        }
+    }
+
+    private func notice(icon: String, color: Color, title: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(color)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(color)
+                Text(detail)
+                    .font(.system(size: 10))
+                    .foregroundColor(Color(.secondaryLabelColor))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.top, 4)
+    }
+}

--- a/Zerm/Views/AI Models/LocalLLMModelCardView.swift
+++ b/Zerm/Views/AI Models/LocalLLMModelCardView.swift
@@ -66,18 +66,23 @@ struct LocalLLMModelCardView: View {
                         Button("Cancel") { manager.cancelDownload(package) }.controlSize(.small)
                     }
                 }
+            } else if package.hardwareFit.blocksInstall {
+                HardwareFitNotice(fit: package.hardwareFit)
             } else {
-                HStack {
-                    Text("Download once to use on-device. No API key needed.")
-                        .font(.caption).foregroundStyle(.secondary)
-                    Spacer()
-                    Button {
-                        manager.select(package)
-                        Task { await manager.download(package) }
-                    } label: {
-                        Label("Download", systemImage: "arrow.down.circle")
+                VStack(alignment: .leading, spacing: 4) {
+                    HardwareFitNotice(fit: package.hardwareFit)
+                    HStack {
+                        Text("Download once to use on-device. No API key needed.")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        Button {
+                            manager.select(package)
+                            Task { await manager.download(package) }
+                        } label: {
+                            Label("Download", systemImage: "arrow.down.circle")
+                        }
+                        .controlSize(.small)
                     }
-                    .controlSize(.small)
                 }
             }
         }

--- a/Zerm/Views/AI Models/ModelManagementView.swift
+++ b/Zerm/Views/AI Models/ModelManagementView.swift
@@ -45,6 +45,8 @@ struct ModelManagementView: View {
             VStack(alignment: .leading, spacing: 24) {
                 if SystemArchitecture.isIntelMac {
                     intelMacWarningBanner
+                } else if HardwareCapability.tier == .limited {
+                    limitedMemoryBanner
                 }
 
                 defaultModelSection
@@ -303,16 +305,33 @@ struct ModelManagementView: View {
         .cornerRadius(8)
     }
 
+    private var limitedMemoryBanner: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "memorychip")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.orange)
+
+            Text("\(HardwareCapability.summary) — recommendations are tuned for this Mac; models that need more memory are marked or unavailable")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.primary.opacity(0.85))
+
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color.orange.opacity(0.08))
+        .cornerRadius(8)
+    }
+
     private var filteredModels: [any TranscriptionModel] {
         switch selectedFilter {
         case .recommended:
+            let recommendedNames = HardwareCapability.recommendedTranscriptionModelNames
             return transcriptionModelManager.allAvailableModels.filter {
-                let recommendedNames = ["ggml-base.en", "parakeet-tdt-0.6b-v2", "ggml-large-v3-turbo-q5_0", "whisper-large-v3-turbo"]
-                return recommendedNames.contains($0.name)
+                recommendedNames.contains($0.name)
             }.sorted { model1, model2 in
-                let recommendedOrder = ["ggml-base.en", "parakeet-tdt-0.6b-v2", "ggml-large-v3-turbo-q5_0", "whisper-large-v3-turbo"]
-                let index1 = recommendedOrder.firstIndex(of: model1.name) ?? Int.max
-                let index2 = recommendedOrder.firstIndex(of: model2.name) ?? Int.max
+                let index1 = recommendedNames.firstIndex(of: model1.name) ?? Int.max
+                let index2 = recommendedNames.firstIndex(of: model2.name) ?? Int.max
                 return index1 < index2
             }
         case .local:

--- a/Zerm/Views/AI Models/WhisperModelCardView.swift
+++ b/Zerm/Views/AI Models/WhisperModelCardView.swift
@@ -25,6 +25,9 @@ struct WhisperModelCardView: View {
                 headerSection
                 metadataSection
                 descriptionSection
+                if !isDownloaded {
+                    HardwareFitNotice(fit: model.hardwareFit)
+                }
                 progressSection
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -128,6 +131,14 @@ struct WhisperModelCardView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                 }
+            } else if model.hardwareFit.blocksInstall {
+                Text("Unavailable")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(Color(.tertiaryLabelColor))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(Color(.quaternaryLabelColor).opacity(0.3)))
+                    .help("This model needs more memory than this Mac has available")
             } else {
                 Button(action: downloadAction) {
                     HStack(spacing: 4) {


### PR DESCRIPTION
## Summary
Adds a recommendation system that rates the user's Mac and gates local-model installs accordingly, so low-power MacBooks are steered to models that actually run well.

- **New `HardwareCapability` service** (`Zerm/Services/HardwareCapability.swift`): reads installed RAM and chip name, classifies the Mac into `limited` (Intel or 8 GB), `capable` (16 GB), or `powerful` (24 GB+), and judges each model's fit from its estimated runtime memory: **good / heavy (warn) / too heavy (blocked)**. Thresholds leave headroom for macOS and other apps (warn above 45% of RAM, block above 70%).
- **Model cards** (Whisper, Parakeet, on-device Gemma) show an inline orange warning for heavy models and replace the Download button with a disabled **Unavailable** state for blocked ones — e.g. Gemma 4 12B/27B can no longer be installed on an 8 GB machine.
- **Download managers** also refuse blocked models, so gating holds for any code path (onboarding, future callers), not just the cards.
- **Recommended tab** is now hardware-tuned instead of a hardcoded list; limited Macs are steered to `base.en`, Parakeet, and cloud turbo.
- **8 GB Apple Silicon banner** mirrors the existing Intel banner and explains why some models are marked or unavailable.
- `LocalLLMPackage` gains `estimatedRAMGB` metadata (weights + KV cache + runtime overhead).

## Testing
- `xcodebuild -scheme Zerm -configuration Debug build` succeeds (remaining warnings are pre-existing Swift 6 concurrency warnings)