### PR TITLE
Optimize local inference and background work for low-power Macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ playground.xcworkspace
 .build/
 build/
 .local-build/
+.test-build/
 .ci-packages/
 
 # Carthage / Accio (unused, kept for safety)

--- a/Zerm/Recorder.swift
+++ b/Zerm/Recorder.swift
@@ -207,7 +207,9 @@ class Recorder: NSObject, ObservableObject {
 
     private func startAudioMeterTimer() {
         let timer = DispatchSource.makeTimerSource(queue: audioMeterQueue)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(17)) 
+        // 30 Hz is smooth for the visualizer at roughly half the wakeup cost of the
+        // previous 17 ms cadence — this runs for the whole recording.
+        timer.schedule(deadline: .now(), repeating: .milliseconds(33))
         timer.setEventHandler { [weak self] in
             self?.updateAudioMeter()
         }
@@ -218,9 +220,9 @@ class Recorder: NSObject, ObservableObject {
     private func updateAudioMeter() {
         guard let recorder = recorder else { return }
 
-        // ~1 Hz capture-health heartbeat while debug logging is on (17 ms ticks)
+        // ~1 Hz capture-health heartbeat while debug logging is on (33 ms ticks)
         meterTickCount += 1
-        if meterTickCount % 59 == 0 {
+        if meterTickCount % 30 == 0 {
             DebugLogger.shared.log("Recorder", "heartbeat: \(recorder.debugSessionStats())")
         }
 

--- a/Zerm/Services/HardwareCapability.swift
+++ b/Zerm/Services/HardwareCapability.swift
@@ -39,6 +39,31 @@ enum HardwareCapability {
         "\(chipName) · \(Int(physicalMemoryGB.rounded())) GB RAM"
     }
 
+    /// Performance cores on Apple Silicon (`hw.perflevel0.physicalcpu`); physical cores
+    /// elsewhere. Spilling inference threads onto efficiency cores or hyperthreads slows
+    /// the P-core work down and costs battery.
+    static let performanceCoreCount: Int = {
+        for key in ["hw.perflevel0.physicalcpu", "hw.physicalcpu"] {
+            var count: Int32 = 0
+            var size = MemoryLayout<Int32>.size
+            if sysctlbyname(key, &count, &size, nil, 0) == 0, count > 0 {
+                return Int(count)
+            }
+        }
+        return ProcessInfo.processInfo.processorCount
+    }()
+
+    /// Thread count for CPU-side inference: stay on the performance cores, and back off
+    /// to half when macOS reports thermal pressure or Low Power Mode.
+    static var inferenceThreadCount: Int {
+        let base = max(1, min(8, performanceCoreCount))
+        let process = ProcessInfo.processInfo
+        if process.isLowPowerModeEnabled || process.thermalState == .serious || process.thermalState == .critical {
+            return max(1, base / 2)
+        }
+        return base
+    }
+
     // MARK: - Per-model fit
 
     enum ModelFit {

--- a/Zerm/Services/ModelPrewarmService.swift
+++ b/Zerm/Services/ModelPrewarmService.swift
@@ -16,6 +16,9 @@ final class ModelPrewarmService: ObservableObject {
     )
     private let prewarmAudioURL = Bundle.main.url(forResource: "esc", withExtension: "wav")
     private let prewarmEnabledKey = "PrewarmModelOnWake"
+    /// Last successful prewarm — brief lid-close cycles shouldn't re-run a full transcription.
+    private var lastPrewarmDate: Date?
+    private let prewarmCooldown: TimeInterval = 10 * 60
 
     init(transcriptionModelManager: TranscriptionModelManager, whisperModelManager: WhisperModelManager, modelContext: ModelContext) {
         self.transcriptionModelManager = transcriptionModelManager
@@ -83,6 +86,7 @@ final class ModelPrewarmService: ObservableObject {
             let _ = try await serviceRegistry.transcribe(audioURL: audioURL, model: currentModel)
             let duration = Date().timeIntervalSince(startTime)
 
+            lastPrewarmDate = Date()
             logger.notice("Prewarm completed in \(String(format: "%.2f", duration), privacy: .public)s")
 
         } catch {
@@ -97,6 +101,23 @@ final class ModelPrewarmService: ObservableObject {
         let isEnabled = UserDefaults.standard.bool(forKey: prewarmEnabledKey)
         guard isEnabled else {
             logger.notice("Prewarm disabled by user")
+            return false
+        }
+
+        // Don't burn battery for a latency optimization.
+        let process = ProcessInfo.processInfo
+        if process.isLowPowerModeEnabled {
+            logger.notice("Skipping prewarm — Low Power Mode is on")
+            return false
+        }
+        if process.thermalState == .serious || process.thermalState == .critical {
+            logger.notice("Skipping prewarm — thermal pressure")
+            return false
+        }
+
+        // A recent prewarm means the model is still resident; short sleeps don't evict it.
+        if let last = lastPrewarmDate, Date().timeIntervalSince(last) < prewarmCooldown {
+            logger.notice("Skipping prewarm — last prewarm was \(Int(-last.timeIntervalSinceNow))s ago")
             return false
         }
 

--- a/Zerm/Transcription/Whisper/LibWhisper.swift
+++ b/Zerm/Transcription/Whisper/LibWhisper.swift
@@ -33,7 +33,8 @@ actor WhisperContext {
     func fullTranscribe(samples: [Float], forceDisableVAD: Bool = false) -> Bool {
         guard let context = context else { return false }
         
-        let maxThreads = max(1, min(8, cpuCount() - 2))
+        // P-core-bound and thermal/Low-Power-aware — see HardwareCapability.
+        let maxThreads = HardwareCapability.inferenceThreadCount
         var params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
         
         // Read language directly from UserDefaults
@@ -184,8 +185,4 @@ actor WhisperContext {
     func setPrompt(_ prompt: String?) {
         self.prompt = prompt
     }
-}
-
-fileprivate func cpuCount() -> Int {
-    ProcessInfo.processInfo.processorCount
 }

--- a/ZermTests/HardwareCapabilityTests.swift
+++ b/ZermTests/HardwareCapabilityTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import Zerm
+
+struct HardwareCapabilityTests {
+
+    @Test func smallModelFitsOn8GB() {
+        let fit = HardwareCapability.fit(forEstimatedRAMGB: 1.5, physicalMemoryGB: 8)
+        guard case .good = fit else {
+            Issue.record("Expected .good, got \(fit)")
+            return
+        }
+    }
+
+    @Test func midModelWarnsOn8GB() {
+        // Gemma 4 E2B (~4 GB peak) should warn but stay installable on 8 GB.
+        let fit = HardwareCapability.fit(forEstimatedRAMGB: 4.0, physicalMemoryGB: 8)
+        guard case .heavy = fit else {
+            Issue.record("Expected .heavy, got \(fit)")
+            return
+        }
+        #expect(!fit.blocksInstall)
+    }
+
+    @Test func largeModelBlockedOn8GB() {
+        // Gemma 4 12B (~9 GB peak) must be blocked on 8 GB.
+        let fit = HardwareCapability.fit(forEstimatedRAMGB: 9.0, physicalMemoryGB: 8)
+        #expect(fit.blocksInstall)
+    }
+
+    @Test func largeModelWarnsOn16GB() {
+        let fit = HardwareCapability.fit(forEstimatedRAMGB: 9.0, physicalMemoryGB: 16)
+        guard case .heavy = fit else {
+            Issue.record("Expected .heavy, got \(fit)")
+            return
+        }
+    }
+
+    @Test func hugeModelBlockedOn16GBButAllowedOn32GB() {
+        // Gemma 3 27B (~19 GB peak).
+        #expect(HardwareCapability.fit(forEstimatedRAMGB: 19.0, physicalMemoryGB: 16).blocksInstall)
+        #expect(!HardwareCapability.fit(forEstimatedRAMGB: 19.0, physicalMemoryGB: 32).blocksInstall)
+    }
+
+    @MainActor
+    @Test func everyLLMPackageHasARAMEstimate() {
+        for package in LocalLLMModelManager.packages {
+            #expect(package.estimatedRAMGB > 0)
+        }
+    }
+
+    @Test func inferenceThreadCountIsSane() {
+        let threads = HardwareCapability.inferenceThreadCount
+        #expect(threads >= 1)
+        #expect(threads <= 8)
+        #expect(HardwareCapability.performanceCoreCount >= 1)
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #261 — makes the runtime behavior hardware-aware, not just the install gating.

- **Whisper thread count binds to performance cores.** `min(8, processorCount - 2)` counted efficiency cores, so an M1 (4P+4E) ran 6 threads and oversubscribed the E-cores. Now `HardwareCapability.inferenceThreadCount` reads `hw.perflevel0.physicalcpu` (physical cores on Intel) and halves the count under Low Power Mode or serious/critical thermal pressure.
- **Prewarm is battery-aware.** `ModelPrewarmService` previously ran a full sample transcription on every wake-from-sleep. It now skips in Low Power Mode and under thermal pressure, and adds a 10-minute cooldown so brief lid-close cycles don't reload the model each time.
- **Audio meter timer: 59 Hz → 30 Hz** while recording; the visualizer looks identical and the debug heartbeat cadence is preserved (~1 Hz).
- **Tests** for the fit thresholds (8/16/32 GB matrix) and thread-count bounds.

## Testing
- `xcodebuild -scheme Zerm -configuration Debug build` succeeds
- Fit-threshold matrix (14 cases across 8/16/32 GB) verified standalone via `swift`
- sysctl probes verified live on this machine (M4 Max: 12 P-cores → 8 threads, unchanged; M1-class machines drop from 6 threads to 4 P-core-bound threads)
- Note: `xcodebuild test` cannot run in this repo's signing setup (ad-hoc test host can't load the Developer-ID-signed whisper.framework — dyld Team ID mismatch); the new unit tests run in Xcode