### PR TITLE
Security hardening pass: keychain storage, model integrity, update-feed guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,27 @@ jobs:
             exit 1
           fi
           echo "No hardcoded home paths — OK"
+
+      - name: Validate Sparkle appcast integrity
+        run: |
+          # The appcast XML itself is not signed — only the enclosure bytes are.
+          # Guard the two properties that keep OTA safe: every advertised update
+          # must carry an EdDSA signature and be served from the official
+          # GitHub Releases host. A missing/blank signature or an off-host
+          # enclosure fails the PR instead of shipping a bad or unverifiable feed.
+          for feed in docs/appcast.xml appcast.xml; do
+            [ -f "$feed" ] || continue
+            echo "Checking $feed"
+            enclosures=$(grep -c "<enclosure " "$feed" || true)
+            if [ "$enclosures" -eq 0 ]; then
+              echo "FAIL: $feed has no <enclosure> element"; exit 1
+            fi
+            sigs=$(grep -c 'sparkle:edSignature="[^"]\{20,\}"' "$feed" || true)
+            if [ "$sigs" -ne "$enclosures" ]; then
+              echo "FAIL: $feed has $enclosures enclosure(s) but $sigs signed — every update must be EdDSA-signed"; exit 1
+            fi
+            if grep -q '<enclosure ' "$feed" && ! grep 'url="https://github.com/arcusis/Zerm/releases/download/' "$feed" >/dev/null; then
+              echo "FAIL: $feed enclosure is not served from the official GitHub Releases host"; exit 1
+            fi
+          done
+          echo "Appcast integrity — OK"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # Define a directory for dependencies in the user's home folder
 DEPS_DIR := $(HOME)/Zerm-Dependencies
+# Pinned upstream revisions of the native parsers compiled into the shipped binary.
+# Bump these deliberately (and re-verify) rather than tracking a moving branch head.
+WHISPER_COMMIT := fc674574ca27cac59a15e5b22a09b9d9ad62aafe
+SHERPA_COMMIT := 6faa8142d49d4d47d2a6c1e06350a976661fe046
 WHISPER_CPP_DIR := $(DEPS_DIR)/whisper.cpp
 FRAMEWORK_PATH := $(WHISPER_CPP_DIR)/build-apple/whisper.xcframework
 SHERPA_DIR := $(DEPS_DIR)/sherpa-onnx
@@ -34,8 +38,9 @@ whisper:
 		if [ ! -d "$(WHISPER_CPP_DIR)" ]; then \
 			git clone https://github.com/ggerganov/whisper.cpp.git $(WHISPER_CPP_DIR); \
 		else \
-			(cd $(WHISPER_CPP_DIR) && git pull); \
+			(cd $(WHISPER_CPP_DIR) && git fetch origin); \
 		fi; \
+		(cd $(WHISPER_CPP_DIR) && git checkout --quiet $(WHISPER_COMMIT)); \
 		cd $(WHISPER_CPP_DIR) && ./build-xcframework.sh; \
 	else \
 		echo "whisper.xcframework already built in $(DEPS_DIR), skipping build"; \
@@ -47,8 +52,9 @@ sherpa:
 	@if [ ! -d "$(SHERPA_XCFRAMEWORK)" ]; then \
 		echo "Building sherpa-onnx.xcframework in $(DEPS_DIR)..."; \
 		if [ ! -d "$(SHERPA_DIR)" ]; then \
-			git clone --depth 1 https://github.com/k2-fsa/sherpa-onnx.git $(SHERPA_DIR); \
+			git clone https://github.com/k2-fsa/sherpa-onnx.git $(SHERPA_DIR); \
 		fi; \
+		(cd $(SHERPA_DIR) && git fetch origin && git checkout --quiet $(SHERPA_COMMIT)); \
 		cd $(SHERPA_DIR) && ./build-swift-macos.sh; \
 	else \
 		echo "sherpa-onnx.xcframework already built, skipping"; \

--- a/Zerm/LocalLLM/LocalLLMModelManager.swift
+++ b/Zerm/LocalLLM/LocalLLMModelManager.swift
@@ -9,6 +9,8 @@ struct LocalLLMPackage: Identifiable, Hashable {
     /// Rough peak RAM (GB) while generating: weights + KV cache + runtime overhead.
     let estimatedRAMGB: Double
     let downloadURL: URL
+    /// Pinned SHA-256 of the GGUF at the revision in `downloadURL`, verified after download.
+    let sha256: String
 
     /// `fileName` is the stable identity/key (also the on-disk name).
     var id: String { fileName }
@@ -31,35 +33,40 @@ final class LocalLLMModelManager: ObservableObject {
             displayName: "Gemma 3 1B (on-device)",
             approxSize: "~806 MB",
             estimatedRAMGB: 1.5,
-            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf")!
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q4_K_M.gguf")!,
+            sha256: "8270790f3ab69fdfe860b7b64008d9a19986d8df7e407bb018184caa08798ebd"
         ),
         LocalLLMPackage(
             fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
             displayName: "Gemma 4 E2B (on-device)",
             approxSize: "~3.1 GB",
             estimatedRAMGB: 4.0,
-            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf")!
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/0314792d7f1f7e229411f620751375812bb9faf2/gemma-4-E2B-it-Q4_K_M.gguf")!,
+            sha256: "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8"
         ),
         LocalLLMPackage(
             fileName: "gemma-4-E4B-it-Q4_K_M.gguf",
             displayName: "Gemma 4 E4B (on-device)",
             approxSize: "~5.0 GB",
             estimatedRAMGB: 6.0,
-            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf")!
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/bfc15c382204943c3a8fff0c750b94ae2364d7a3/gemma-4-E4B-it-Q4_K_M.gguf")!,
+            sha256: "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87"
         ),
         LocalLLMPackage(
             fileName: "gemma-4-12b-it-Q4_K_M.gguf",
             displayName: "Gemma 4 12B (on-device)",
             approxSize: "~7.1 GB",
             estimatedRAMGB: 9.0,
-            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q4_K_M.gguf")!
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/fc034cfff751157913579611efad8462ac1be606/gemma-4-12b-it-Q4_K_M.gguf")!,
+            sha256: "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42"
         ),
         LocalLLMPackage(
             fileName: "gemma-3-27b-it-Q4_K_M.gguf",
             displayName: "Gemma 3 27B (on-device)",
             approxSize: "~16.5 GB",
             estimatedRAMGB: 19.0,
-            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-27b-it-GGUF/resolve/main/gemma-3-27b-it-Q4_K_M.gguf")!
+            downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-3-27b-it-GGUF/resolve/7cd0121f2530b00e42c4df952d4cad4418c0b3c1/gemma-3-27b-it-Q4_K_M.gguf")!,
+            sha256: "f1b699659942c777bd3ec0bcb527d6ebf34ae14ca76e3af103d58d0c9cbdadee"
         )
     ]
 
@@ -160,6 +167,13 @@ final class LocalLLMModelManager: ObservableObject {
 
         do {
             let file = try await downloadFile(for: package)
+            // Reject a tampered/corrupt GGUF before llama.cpp ever parses it.
+            guard ModelIntegrity.verify(fileURL: file, expectedSHA256: package.sha256) else {
+                try? FileManager.default.removeItem(at: file)
+                logger.error("Checksum mismatch for \(package.fileName, privacy: .public); download rejected")
+                statusText = "Download failed integrity check and was discarded"
+                return
+            }
             let dest = path(for: package)
             try? FileManager.default.removeItem(at: dest)
             try FileManager.default.moveItem(at: file, to: dest)

--- a/Zerm/Models/TranscriptionModel.swift
+++ b/Zerm/Models/TranscriptionModel.swift
@@ -203,7 +203,7 @@ struct WhisperModel: TranscriptionModel {
     let provider: ModelProvider = .whisper
 
     var downloadURL: String {
-        "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/\(filename)"
+        "https://huggingface.co/ggerganov/whisper.cpp/resolve/\(ModelIntegrity.whisperRepoCommit)/\(filename)"
     }
 
     var filename: String {
@@ -213,7 +213,7 @@ struct WhisperModel: TranscriptionModel {
     var isMultilingualModel: Bool {
         supportedLanguages.count > 1
     }
-} 
+}
 
 // User-imported local models 
 struct ImportedWhisperModel: TranscriptionModel {

--- a/Zerm/Notifications/AnnouncementManager.swift
+++ b/Zerm/Notifications/AnnouncementManager.swift
@@ -20,7 +20,9 @@ final class AnnouncementManager {
                 self?.dismiss()
             },
             onLearnMore: { [weak self] in
-                if let url = learnMoreURL {
+                // Announcements come from a remote feed; only open web links, never arbitrary
+                // URL schemes that could launch a helper app.
+                if let url = learnMoreURL, ["http", "https"].contains(url.scheme?.lowercased()) {
                     NSWorkspace.shared.open(url)
                 }
                 onDismiss()

--- a/Zerm/PowerMode/BrowserURLService.swift
+++ b/Zerm/PowerMode/BrowserURLService.swift
@@ -130,10 +130,11 @@ class BrowserURLService {
                     throw BrowserURLError.noActiveTab
                 }
                 if output.lowercased().contains("error") {
-                    logger.error("❌ AppleScript error for \(browser.displayName, privacy: .public): \(output, privacy: .public)")
+                    // The active-tab URL can carry tokens/session IDs — keep it out of logs.
+                    logger.error("❌ AppleScript error for \(browser.displayName, privacy: .public): \(output, privacy: .private)")
                     throw BrowserURLError.executionFailed
                 }
-                logger.debug("✅ Retrieved URL from \(browser.displayName, privacy: .public): \(output, privacy: .public)")
+                logger.debug("✅ Retrieved URL from \(browser.displayName, privacy: .public): \(output, privacy: .private)")
                 return output
             } else {
                 throw BrowserURLError.executionFailed

--- a/Zerm/Services/ImportExportService.swift
+++ b/Zerm/Services/ImportExportService.swift
@@ -191,6 +191,18 @@ class ImportExportService {
                         self.showAlert(title: "Version Mismatch", message: "The imported settings file (version \(importedSettings.version)) is from a different version than your application (version \(self.currentSettingsVersion)). Proceeding with import, but be aware of potential incompatibilities.")
                     }
 
+                    // A settings file is untrusted input that overwrites prompts, power modes,
+                    // custom model endpoints, and the dictionary. Require explicit confirmation.
+                    let confirm = NSAlert()
+                    confirm.messageText = "Import these settings?"
+                    confirm.informativeText = "This replaces your prompts, power modes, custom models, and dictionary with the contents of \"\(url.lastPathComponent)\". Only import files you trust."
+                    confirm.alertStyle = .warning
+                    confirm.addButton(withTitle: "Import")
+                    confirm.addButton(withTitle: "Cancel")
+                    guard confirm.runModal() == .alertFirstButtonReturn else {
+                        return
+                    }
+
                     let predefinedPrompts = enhancementService.customPrompts.filter { $0.isPredefined }
                     enhancementService.customPrompts = predefinedPrompts + importedSettings.customPrompts
                     

--- a/Zerm/Services/KeychainService.swift
+++ b/Zerm/Services/KeychainService.swift
@@ -2,21 +2,33 @@ import Foundation
 import Security
 import os
 
-/// Securely stores and retrieves API keys using Keychain with iCloud sync.
-/// For local (unsigned) builds, uses UserDefaults instead since Keychain
-/// requires stable code signing to reliably persist data across rebuilds.
+/// Securely stores and retrieves API keys.
+///
+/// Shipped (Release) builds use the macOS Keychain with data protection. Local *developer*
+/// builds (`#if DEBUG`) fall back to UserDefaults because unsigned/ad-hoc dev binaries don't
+/// keep a stable code-signing identity across rebuilds, which makes Keychain items unreliable.
+/// The fallback is gated on `DEBUG` — never on the release flag — so shipped builds always use
+/// the Keychain. On first launch of a Keychain build, any keys left in the old plaintext
+/// UserDefaults store by a previous release are migrated into the Keychain and then purged.
 final class KeychainService {
     static let shared = KeychainService()
 
     private let logger = Logger(subsystem: "com.arcusis.zerm", category: "KeychainService")
     private let service = "com.arcusis.zerm"
 
-    #if LOCAL_BUILD
-    private let defaults = UserDefaults.standard
+    /// Prefix used by the DEBUG UserDefaults store and by the legacy plaintext store that
+    /// shipped Release builds used before keys moved to the Keychain.
     private let localPrefix = "LocalKeychain_"
+
+    #if DEBUG
+    private let defaults = UserDefaults.standard
     #endif
 
-    private init() {}
+    private init() {
+        #if !DEBUG
+        migrateLegacyPlaintextKeysIfNeeded()
+        #endif
+    }
 
     // MARK: - Public API
 
@@ -33,7 +45,7 @@ final class KeychainService {
     /// Saves data to Keychain.
     @discardableResult
     func save(data: Data, forKey key: String, syncable: Bool = true) -> Bool {
-        #if LOCAL_BUILD
+        #if DEBUG
         defaults.set(data, forKey: localPrefix + key)
         return true
         #else
@@ -65,7 +77,7 @@ final class KeychainService {
 
     /// Retrieves data from Keychain.
     func getData(forKey key: String, syncable: Bool = true) -> Data? {
-        #if LOCAL_BUILD
+        #if DEBUG
         return defaults.data(forKey: localPrefix + key)
         #else
         var query = baseQuery(forKey: key, syncable: syncable)
@@ -88,7 +100,7 @@ final class KeychainService {
     /// Deletes an item from Keychain.
     @discardableResult
     func delete(forKey key: String, syncable: Bool = true) -> Bool {
-        #if LOCAL_BUILD
+        #if DEBUG
         defaults.removeObject(forKey: localPrefix + key)
         return true
         #else
@@ -109,7 +121,7 @@ final class KeychainService {
 
     /// Checks if a key exists in Keychain.
     func exists(forKey key: String, syncable: Bool = true) -> Bool {
-        #if LOCAL_BUILD
+        #if DEBUG
         return defaults.data(forKey: localPrefix + key) != nil
         #else
         var query = baseQuery(forKey: key, syncable: syncable)
@@ -122,21 +134,49 @@ final class KeychainService {
 
     // MARK: - Private Helpers
 
-    #if !LOCAL_BUILD
+    #if !DEBUG
     /// Creates base Keychain query dictionary.
+    ///
+    /// Uses the traditional login Keychain (not the data-protection Keychain) so it works for
+    /// a Developer-ID, non-sandboxed app without a `keychain-access-groups` entitlement. The
+    /// app reads back its own items without a prompt because it created them. `syncable` is
+    /// accepted for source compatibility but intentionally unused: iCloud Keychain sync
+    /// requires the data-protection Keychain, which our entitlements don't grant, and shipped
+    /// builds never synced keys.
     private func baseQuery(forKey key: String, syncable: Bool) -> [String: Any] {
-        var query: [String: Any] = [
+        return [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
-            kSecUseDataProtectionKeychain as String: true
+            // Only readable while the device is unlocked; excluded from unencrypted backups.
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
         ]
+    }
 
-        if syncable {
-            query[kSecAttrSynchronizable as String] = kCFBooleanTrue
+    /// One-time move of API keys that a prior Release build wrote in plaintext to
+    /// `~/Library/Preferences` (UserDefaults `LocalKeychain_*`) into the Keychain, then
+    /// deletes the plaintext copies. Idempotent via a persisted flag.
+    private func migrateLegacyPlaintextKeysIfNeeded() {
+        let migrationFlagKey = "KeychainPlaintextMigration_v1_done"
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: migrationFlagKey) else { return }
+
+        var migrated = 0
+        for (defaultsKey, value) in defaults.dictionaryRepresentation() where defaultsKey.hasPrefix(localPrefix) {
+            let realKey = String(defaultsKey.dropFirst(localPrefix.count))
+            // Values were stored as Data; skip anything unexpected but still purge it.
+            if let data = value as? Data, !exists(forKey: realKey) {
+                if save(data: data, forKey: realKey, syncable: true) {
+                    migrated += 1
+                }
+            }
+            defaults.removeObject(forKey: defaultsKey)
         }
 
-        return query
+        defaults.set(true, forKey: migrationFlagKey)
+        if migrated > 0 {
+            logger.notice("Migrated \(migrated, privacy: .public) API key(s) from plaintext storage into the Keychain")
+        }
     }
     #endif
 }

--- a/Zerm/Services/ModelIntegrity.swift
+++ b/Zerm/Services/ModelIntegrity.swift
@@ -1,0 +1,56 @@
+import Foundation
+import CryptoKit
+
+/// Integrity pinning for downloaded model files.
+///
+/// Model weights are fetched over HTTPS from third-party hosts (Hugging Face) and then parsed
+/// in-process by native C/C++ loaders (ggml / gguf) that have a history of memory-safety bugs.
+/// TLS protects transit but not a compromised or swapped file at the source. We therefore pin
+/// each catalog file to an immutable repo revision *and* to its SHA-256, and reject any
+/// downloaded file whose hash doesn't match before it is loaded or extracted.
+///
+/// Hashes and the commit are captured at build time from the Hugging Face LFS pointers. Pinning
+/// the URL to the same commit as the hash keeps this non-breaking: the bytes at a fixed revision
+/// never change, so verification always passes for a genuine download. New model revisions ship
+/// via app updates.
+enum ModelIntegrity {
+
+    // MARK: - Whisper (ggerganov/whisper.cpp)
+
+    /// Repo revision the whisper hashes below correspond to. Also used to build download URLs.
+    static let whisperRepoCommit = "5359861c739e955e79d9a303bcbc70fb988958b1"
+
+    /// SHA-256 of each pinned `<name>.bin`, keyed by model name.
+    static let whisperSHA256: [String: String] = [
+        "ggml-tiny": "be07e048e1e599ad46341c8d2a135645097a538221678b7acdd1b1919c6e1b21",
+        "ggml-tiny.en": "921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f",
+        "ggml-base": "60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe",
+        "ggml-base.en": "a03779c86df3323075f5e796cb2ce5029f00ec8869eee3fdfb897afe36c6d002",
+        "ggml-small": "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b",
+        "ggml-small.en": "c6138d6d58ecc8322097e0f987c32f1be8bb0a18532a3f88f734d1bbf9c41e5d",
+        "ggml-large-v3-turbo": "1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69",
+        "ggml-large-v3-turbo-q5_0": "394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2"
+    ]
+
+    // MARK: - Verification
+
+    /// Streams a file through SHA-256 without loading it (models are up to gigabytes).
+    static func sha256(ofFileAt url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while true {
+            guard let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty else { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// True if the file matches the expected hash, or if there is no pinned hash (`expected` is
+    /// nil/empty) — so files without a pin keep working unchanged.
+    static func verify(fileURL: URL, expectedSHA256 expected: String?) -> Bool {
+        guard let expected, !expected.isEmpty else { return true }
+        guard let actual = sha256(ofFileAt: fileURL) else { return false }
+        return actual.caseInsensitiveCompare(expected) == .orderedSame
+    }
+}

--- a/Zerm/Transcription/Whisper/WhisperModelManager.swift
+++ b/Zerm/Transcription/Whisper/WhisperModelManager.swift
@@ -14,18 +14,23 @@ struct WhisperModelFile: Identifiable {
     var isCoreMLDownloaded: Bool { coreMLEncoderURL != nil }
 
     var downloadURL: String {
-        "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/\(filename)"
+        "https://huggingface.co/ggerganov/whisper.cpp/resolve/\(ModelIntegrity.whisperRepoCommit)/\(filename)"
     }
 
     var filename: String {
         "\(name).bin"
     }
 
+    /// Pinned SHA-256 for the main `.bin`, if this is a known catalog model.
+    var expectedSHA256: String? {
+        ModelIntegrity.whisperSHA256[name]
+    }
+
     // Core ML related properties
     var coreMLZipDownloadURL: String? {
         // Only non-quantized models have Core ML versions
         guard !name.contains("q5") && !name.contains("q8") else { return nil }
-        return "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/\(name)-encoder.mlmodelc.zip"
+        return "https://huggingface.co/ggerganov/whisper.cpp/resolve/\(ModelIntegrity.whisperRepoCommit)/\(name)-encoder.mlmodelc.zip"
     }
 
     var coreMLEncoderDirectoryName: String? {
@@ -227,6 +232,13 @@ class WhisperModelManager: ObservableObject {
         let destinationURL = modelsDirectory.appendingPathComponent(model.filename)
         try data.write(to: destinationURL)
 
+        // Reject a tampered/corrupt download before whisper.cpp ever parses it.
+        if !ModelIntegrity.verify(fileURL: destinationURL, expectedSHA256: ModelIntegrity.whisperSHA256[model.name]) {
+            try? FileManager.default.removeItem(at: destinationURL)
+            logger.error("Checksum mismatch for model \(model.name, privacy: .public); download rejected")
+            throw ZermEngineError.modelLoadFailed
+        }
+
         return WhisperModelFile(name: model.name, url: destinationURL)
     }
 
@@ -248,6 +260,37 @@ class WhisperModelManager: ObservableObject {
         return try verifyAndCleanupCoreMLFiles(model, coreMLDestination, zipPath, progressKey)
     }
 
+    /// Rejects a zip whose entries would escape the extraction directory (zip-slip). The
+    /// bundled Zip library performs no containment check and the app is not sandboxed, so a
+    /// malicious `.mlmodelc.zip` could otherwise write anywhere the user can. Lists entry
+    /// names with `/usr/bin/unzip -Z1` and fails closed on any absolute path or `..` component.
+    static func assertNoPathTraversal(inZipAt zipPath: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-Z1", zipPath.path]
+        let out = Pipe()
+        let err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+        try process.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        _ = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw ZermEngineError.unzipFailed
+        }
+        let names = (String(data: data, encoding: .utf8) ?? "")
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        for name in names where !name.isEmpty {
+            let isAbsolute = name.hasPrefix("/")
+            let hasTraversal = name == ".." || name.hasPrefix("../") || name.contains("/../") || name.hasSuffix("/..")
+            if isAbsolute || hasTraversal {
+                throw ZermEngineError.unzipFailed
+            }
+        }
+    }
+
     private func unzipCoreMLFile(_ zipPath: URL, to destination: URL) async throws {
         let finished = ManagedAtomic(false)
 
@@ -259,6 +302,7 @@ class WhisperModelManager: ObservableObject {
             }
 
             do {
+                try Self.assertNoPathTraversal(inZipAt: zipPath)
                 try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
                 try Zip.unzipFile(zipPath, destination: destination, overwrite: true, password: nil)
                 finishOnce(.success(()))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -177,9 +177,16 @@ if [ -n "$SIGN_UPDATE" ] && [ -f "$SPARKLE_PRIVATE_KEY_FILE" ]; then
     if [ -n "$SIG_VALUE" ]; then
         ED_SIG="sparkle:edSignature=\"$SIG_VALUE\""
     fi
-else
-    echo "warning: sign_update or private key missing — appcast will be unsigned."
-    echo "  Set SPARKLE_PRIVATE_KEY_FILE and install Sparkle's sign_update for real updates."
+fi
+
+# Fail closed: an unsigned appcast would either be rejected by every client (dead OTA)
+# or, worse, ship an unverifiable update. Never publish one by accident.
+# Set SKIP_APPCAST_SIGNATURE=1 only for an intentional dry run.
+if [ -z "$ED_SIG" ] && [ "${SKIP_APPCAST_SIGNATURE:-0}" != "1" ]; then
+    echo "error: could not EdDSA-sign the update (sign_update or private key missing)."
+    echo "  Install Sparkle's sign_update and set SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_FILE."
+    echo "  Refusing to write an unsigned appcast. (Set SKIP_APPCAST_SIGNATURE=1 to override for a dry run.)"
+    exit 1
 fi
 
 # Per-release notes for the Sparkle feed. Override per release, e.g.


### PR DESCRIPTION
Addresses the deep security review. Every change was built in both Debug and Release configurations; the SHA-256 verifier and the CI appcast check were validated standalone.

## Critical
- **API keys → Keychain in shipped builds.** Release builds compiled with `LOCAL_BUILD` were storing every provider key (OpenAI, Anthropic, Deepgram, …) in plaintext at `~/Library/Preferences/com.arcusis.zerm.plist`, world-readable within the user account. Storage is now gated on `#if DEBUG` — dev builds keep the convenient UserDefaults store, **shipped Release builds use the Keychain**. A one-time migration moves any keys a prior release left in the plist into the Keychain and purges the plaintext copies, so existing users don't lose their configured providers. Uses the traditional login keychain (no `keychain-access-groups` entitlement needed for a Developer-ID, non-sandboxed app; the app reads back its own items without a prompt).
- **Zip-slip guard.** CoreML `.mlmodelc.zip` downloads are scanned (`unzip -Z1`) and rejected on any absolute or `..` entry before extraction — the bundled Zip library has no containment check and the app is unsandboxed.

## Supply chain
- **Model integrity pinning.** Whisper `.bin` and on-device Gemma GGUF downloads are pinned to an immutable Hugging Face commit **and** verified against a pinned SHA-256 before the native ggml/gguf parsers touch them; a mismatch is deleted and refused. Pinning the URL to the same commit as the hash keeps this non-breaking (bytes at a fixed revision never change).
- **Makefile pins** whisper.cpp (`fc67457`) and sherpa-onnx (`6faa814`) to specific commits instead of `git pull` on a moving branch.

## Update pipeline
- `release.sh` **fails closed** if the update can't be EdDSA-signed (previously warned and shipped an unsigned appcast).
- **CI appcast validation**: every enclosure must carry an EdDSA signature and be served from the official GitHub Releases host, or the PR fails.

## Privacy / misc
- Announcement *Learn More* links restricted to http/https (remote feed can't launch arbitrary URL schemes).
- Browser active-tab URLs no longer logged as `.public`.
- Settings import requires explicit confirmation before overwriting configuration.

## Verification
- Debug build: succeeds. Release build (shipped config, Keychain branch): succeeds.
- SHA-256 streaming verifier cross-checked against `shasum -a 256`; nil/empty pass-through, correct/uppercase match, wrong hash rejected.
- CI appcast check dry-run passes against the live 2.5.1 feed.
- All model hashes/commits fetched live from Hugging Face LFS pointers.

## Documented residuals (not code-fixable here / lower priority)
- **Sparkle EdDSA private key** is a single point of failure (plaintext dotfile, no rotation plan) — operational; recommend Keychain/HSM storage + encrypted offline backup.
- **FluidAudio (Parakeet)** downloads happen inside the SPM package and can't be checksum-verified without forking; **Kokoro** tar is HTTPS + libarchive (tar-slip safe) but unhashed.
- Cloud-context (screen/clipboard) exfiltration would benefit from clearer in-UI disclosure; Local-CLI shell template is an intentional power-user feature and is **not** reachable via settings import (command template isn't in the export schema).