### PR TITLE
Redesign the site around the three on-device models

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Zerm - on-device voice for macOS (dictation + read aloud)</title>
+    <title>Zerm — on-device voice for macOS (dictation + read aloud)</title>
     <meta
       name="description"
-      content="Zerm is a GPLv3 macOS app for dictation and read-aloud, powered by three on-device AI models (speech-to-text, text-to-speech, and a small LLM). Based on VoiceInk."
+      content="Zerm dictates clean text at your cursor and reads any selection back aloud. Three on-device models — Whisper, Kokoro, Gemma — so it is fast, private, and works offline. GPLv3, based on VoiceInk."
     />
-    <meta property="og:title" content="Zerm - on-device voice for macOS" />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="Zerm — on-device voice for macOS" />
     <meta
       property="og:description"
-      content="Dictate and paste, or read any text aloud — on three on-device AI models, fast and private. GPLv3, based on VoiceInk by Beingpax."
+      content="Dictate anywhere. Read anything aloud. Three on-device models, nothing leaves your Mac unless you ask. GPLv3, based on VoiceInk by Beingpax."
     />
     <meta property="og:image" content="./icon.png" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -20,227 +21,431 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <div class="announce">
+      <span class="announce-dot" aria-hidden="true"></span>
+      <span
+        >Zerm <span id="release-tag">latest</span> — dictation and read aloud,
+        running on-device.</span
+      >
+      <a href="https://github.com/arcusis/Zerm/releases">Release notes</a>
+    </div>
+
     <header class="topbar">
-      <a class="brand" href="./" aria-label="Zerm home">
-        <img src="./icon.png" alt="" class="brand-logo" />
-        <span>Zerm</span>
-      </a>
-      <nav class="topbar-nav" aria-label="Primary navigation">
-        <a href="#download">Download</a>
-        <a href="#native">Native layer</a>
-        <a href="#origin">Origin</a>
-        <a href="#privacy">Privacy</a>
-        <a href="https://github.com/arcusis/Zerm" rel="noreferrer">GitHub</a>
-      </nav>
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="#models">Models</a>
+          <a href="#dictation">Dictation</a>
+          <a href="#read-aloud">Read aloud</a>
+          <a href="#privacy">Privacy</a>
+          <a href="#origin">Origin</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="#download">Download</a>
+        </div>
+      </div>
     </header>
 
-    <main>
+    <main id="main">
       <section class="hero">
-        <div class="hero-copy">
-          <img src="./icon.png" alt="Zerm app logo" class="hero-logo" />
-          <p class="kicker">GPLv3 · on-device voice for macOS</p>
-          <h1>Zerm turns speech into clean text — and reads it back.</h1>
-          <p class="hero-lede">
-            Tap a hotkey to dictate and paste, or select any text and have Zerm
-            read it aloud. It runs on three on-device AI models — speech-to-text,
-            text-to-speech, and a small agentic LLM — so the core experience is
-            fast, private, and works offline. Based on VoiceInk by Beingpax,
-            adapted for Arcusis under GPLv3.
+        <div class="hero-copy reveal">
+          <p class="eyebrow">Three on-device models · macOS</p>
+          <h1>Dictate anywhere.<br />Read anything aloud.</h1>
+          <p class="lede">
+            Press a shortcut and Zerm drops clean text at your cursor. Select any
+            text and it reads back in a natural voice. Whisper, Kokoro, and Gemma
+            run locally — fast, private, offline. Cloud providers stay optional,
+            and off by default.
           </p>
+
           <div class="hero-actions">
-            <a id="primary-download" class="button primary" href="#download">
+            <a id="primary-download" class="btn btn-light btn-lg" href="#download">
               <span class="btn-label">Download for macOS</span>
-              <span class="btn-sub" id="primary-download-sub">loading…</span>
+              <span class="btn-sub" id="primary-download-sub">checking latest…</span>
             </a>
-            <a class="button secondary" href="https://github.com/arcusis/Zerm">View source</a>
-            <a class="button secondary" href="https://github.com/Beingpax/VoiceInk">VoiceInk upstream</a>
+            <a class="btn btn-dark btn-lg" href="https://github.com/arcusis/Zerm">
+              <span class="btn-label">View source</span>
+              <span class="btn-sub">GPLv3 · Swift</span>
+            </a>
           </div>
-          <div class="release-line" aria-live="polite">
-            <span id="release-tag">latest release</span>
-            <span>GPLv3 licensed</span>
-            <span>VoiceInk credited</span>
-          </div>
+
+          <ul class="hero-meta" aria-label="Requirements">
+            <li>macOS 14.4+</li>
+            <li>Apple Silicon</li>
+            <li>No account</li>
+            <li>GPLv3</li>
+          </ul>
         </div>
 
-        <div class="workflow-panel" aria-label="Zerm recording workflow">
-          <div class="pill-preview">
-            <span class="record-dot"></span>
-            <span class="wave" style="--h: 10px"></span>
-            <span class="wave" style="--h: 18px"></span>
-            <span class="wave" style="--h: 26px"></span>
-            <span class="wave" style="--h: 16px"></span>
-            <span class="wave" style="--h: 22px"></span>
-            <span class="wave" style="--h: 12px"></span>
-          </div>
-          <div class="workflow-steps">
-            <div>
-              <span>01</span>
-              <strong>Record</strong>
-              <p>Use a global macOS shortcut or push-to-talk style recording.</p>
+        <div class="hero-stage reveal" aria-hidden="true">
+          <div class="window">
+            <div class="window-bar">
+              <span class="dot dot-r"></span>
+              <span class="dot dot-y"></span>
+              <span class="dot dot-g"></span>
+              <span class="window-title">Zerm</span>
             </div>
-            <div>
-              <span>02</span>
-              <strong>Transcribe</strong>
-              <p>Use local and explicitly configured transcription engines.</p>
-            </div>
-            <div>
-              <span>03</span>
-              <strong>Paste</strong>
-              <p>The result lands in your clipboard, with optional native auto-paste on macOS.</p>
+
+            <div class="window-body">
+              <div class="pill">
+                <span class="rec"></span>
+                <span class="wave">
+                  <i style="--h: 8px"></i><i style="--h: 17px"></i><i style="--h: 26px"></i
+                  ><i style="--h: 14px"></i><i style="--h: 22px"></i><i style="--h: 30px"></i
+                  ><i style="--h: 12px"></i><i style="--h: 20px"></i><i style="--h: 9px"></i>
+                </span>
+                <span class="pill-time">00:04</span>
+              </div>
+
+              <div class="cue">
+                <kbd>Right ⌘</kbd>
+                <span>hold to talk · release to paste</span>
+              </div>
+
+              <div class="transcript">
+                <p>
+                  Ship the release notes before standup and mention the new
+                  read-aloud shortcut.<span class="caret"></span>
+                </p>
+              </div>
+
+              <div class="window-foot">
+                <span><b>whisper</b> large-v3-turbo</span>
+                <span class="sep"></span>
+                <span>on-device</span>
+                <span class="sep"></span>
+                <span>1.2s</span>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="strip" aria-label="Highlights">
-        <div>
-          <strong>Local first</strong>
-          <span>Local transcription paths keep audio on the machine.</span>
-        </div>
-        <div>
-          <strong>VoiceInk lineage</strong>
-          <span>Built from the GPLv3 VoiceInk foundation with public credit.</span>
-        </div>
-        <div>
-          <strong>Auditable</strong>
-          <span>Swift, SwiftUI, transparent source, and GPLv3 license terms.</span>
-        </div>
+      <section class="logostrip" aria-label="Runtimes">
+        <p>Local runtimes bundled and managed for you</p>
+        <ul>
+          <li>whisper.cpp</li>
+          <li>sherpa-onnx</li>
+          <li>llama.cpp</li>
+          <li>FluidAudio</li>
+          <li>Apple Speech</li>
+        </ul>
       </section>
 
-      <section id="native" class="section native-layer">
-        <div class="section-head">
-          <p class="kicker">Native writing layer</p>
-          <h2>Built around the OS behaviors that make dictation reliable.</h2>
-          <p>
-            Zerm focuses on the macOS behaviors that matter for fast dictation:
-            permissions, active app context, insertion state, model selection,
-            recording feedback, and reliable paste behavior.
+      <section id="models" class="section">
+        <div class="section-head reveal">
+          <p class="eyebrow">The engine room</p>
+          <h2>Three models. All on your Mac.</h2>
+          <p class="sub">
+            Zerm downloads and manages each one for you. No API key, no signup, no
+            round trip — the whole loop from microphone to pasted text to spoken
+            playback can run with the network off.
           </p>
         </div>
 
-        <div class="native-grid">
-          <div>
-            <span>01</span>
-            <strong>macOS auto-paste</strong>
-            <p>Uses native macOS permissions and insertion paths to paste the transcript at your cursor.</p>
-          </div>
-          <div>
-            <span>02</span>
-            <strong>Power Mode context</strong>
-            <p>Detects active apps and browser URLs so prompts can adapt to the place you are writing.</p>
-          </div>
-          <div>
-            <span>03</span>
-            <strong>Visible permissions</strong>
-            <p>Surfaces microphone, Accessibility, and screen-context requirements instead of hiding setup failures.</p>
-          </div>
+        <div class="model-grid">
+          <article class="card model-card reveal">
+            <span class="card-idx">01</span>
+            <h3>Whisper</h3>
+            <p class="card-role">Speech&nbsp;→&nbsp;Text</p>
+            <p>
+              Dictation and audio-file transcription. Runs on
+              <code>whisper.cpp</code> with Metal acceleration, so a paragraph
+              lands in about a second.
+            </p>
+            <span class="tag">whisper.cpp</span>
+          </article>
+
+          <article class="card model-card reveal">
+            <span class="card-idx">02</span>
+            <h3>Kokoro</h3>
+            <p class="card-role">Text&nbsp;→&nbsp;Speech</p>
+            <p>
+              The Read Aloud voice. Runs on <code>sherpa-onnx</code> and sounds
+              natural enough to listen to a long document without fatigue.
+            </p>
+            <span class="tag">sherpa-onnx</span>
+          </article>
+
+          <article class="card model-card reveal">
+            <span class="card-idx">03</span>
+            <h3>Gemma</h3>
+            <p class="card-role">The agentic layer</p>
+            <p>
+              Cleans up dictated text and rewrites messy source into something
+              worth hearing. Runs on <code>llama.cpp</code>.
+            </p>
+            <span class="tag">llama.cpp</span>
+          </article>
+        </div>
+      </section>
+
+      <section id="dictation" class="section split">
+        <div class="split-copy reveal">
+          <p class="eyebrow">Dictation</p>
+          <h2>Talk. It types.</h2>
+          <p class="sub">
+            A global shortcut works in every app — editor, terminal, browser,
+            Slack. Zerm handles the parts that usually break: permissions, the
+            active insertion point, and pasting without stealing focus.
+          </p>
+
+          <ol class="steps">
+            <li>
+              <b>Hold the shortcut</b>
+              <span>Push-to-talk, or tap to toggle with auto-stop on silence.</span>
+            </li>
+            <li>
+              <b>Speak normally</b>
+              <span>Whisper transcribes locally while you are still talking.</span>
+            </li>
+            <li>
+              <b>Release</b>
+              <span>Clean text is pasted at your cursor, or copied if you prefer.</span>
+            </li>
+          </ol>
+
+          <a class="text-link" href="https://github.com/arcusis/Zerm/blob/Production/docs/native-writing-layer-verification.md"
+            >Native writing layer verification</a
+          >
         </div>
 
-        <a class="text-link" href="https://github.com/arcusis/Zerm/blob/Production/docs/native-writing-layer-verification.md">Read native verification checklist</a>
+        <div class="split-visual reveal" aria-hidden="true">
+          <div class="panel">
+            <div class="panel-row">
+              <span class="panel-key"><kbd>Right ⌘</kbd></span>
+              <span class="panel-label">Dictate &amp; paste — the default</span>
+            </div>
+            <div class="panel-row">
+              <span class="panel-key"><kbd>⌥</kbd><kbd>⌃</kbd><kbd>Fn</kbd></span>
+              <span class="panel-label">Or any other modifier, left or right</span>
+            </div>
+            <div class="panel-row">
+              <span class="panel-key"><kbd>Assign</kbd></span>
+              <span class="panel-label">Read selection aloud — pick your own key</span>
+            </div>
+            <div class="panel-row muted">
+              <span class="panel-key"><kbd>Esc</kbd></span>
+              <span class="panel-label">Cancel — nothing is written</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="read-aloud" class="section split reverse">
+        <div class="split-copy reveal">
+          <p class="eyebrow">Read aloud</p>
+          <h2>Select text. Hear it.</h2>
+          <p class="sub">
+            Zerm reads whatever you have highlighted, anywhere in macOS. Before it
+            speaks, Smart Reading cleans the text so the voice does not read your
+            markup out loud.
+          </p>
+
+          <ul class="checks">
+            <li>Acronyms and units expanded the way a person would say them</li>
+            <li>URLs, code blocks, and tables summarised rather than spelled out</li>
+            <li>Emoji and markdown syntax dropped</li>
+            <li>Optional rewrite pass by the on-device LLM</li>
+          </ul>
+        </div>
+
+        <div class="split-visual reveal" aria-hidden="true">
+          <div class="panel read-panel">
+            <p class="read-source">
+              See <mark>§4.2</mark> — the <code>POST /v1/ingest</code> endpoint
+              returns <mark>202</mark> ✅
+            </p>
+            <div class="read-arrow">Smart Reading</div>
+            <p class="read-out">
+              “See section four point two — the ingest endpoint returns a two
+              oh two accepted.”
+            </p>
+            <div class="speaker">
+              <span class="speaker-icon"></span>
+              <span class="speaker-bars"><i></i><i></i><i></i><i></i><i></i></span>
+              <span class="speaker-name">Kokoro · on-device</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head reveal">
+          <p class="eyebrow">Everything else</p>
+          <h2>The rest of the workflow.</h2>
+        </div>
+
+        <div class="feature-grid">
+          <div class="card reveal">
+            <h3>Power Mode</h3>
+            <p>
+              Detects the active app and browser URL, then swaps the prompt to
+              match where you are writing.
+            </p>
+          </div>
+          <div class="card reveal">
+            <h3>Personal dictionary</h3>
+            <p>
+              Teach it the names, products, and jargon that transcription models
+              reliably get wrong.
+            </p>
+          </div>
+          <div class="card reveal">
+            <h3>History</h3>
+            <p>
+              Every transcript kept locally, searchable, and deletable — including
+              the audio, if you keep it.
+            </p>
+          </div>
+          <div class="card reveal">
+            <h3>Audio files</h3>
+            <p>
+              Drop in a recording or a voice memo and get a transcript with the
+              same local pipeline.
+            </p>
+          </div>
+          <div class="card reveal">
+            <h3>Local or cloud</h3>
+            <p>
+              Whisper, FluidAudio, or Apple for speech; Gemma or Ollama for the
+              LLM; plus any cloud provider you configure yourself.
+            </p>
+          </div>
+          <div class="card reveal">
+            <h3>Honest permissions</h3>
+            <p>
+              Microphone, Accessibility, and screen context are each requested in
+              context — and setup failures are surfaced, not swallowed.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="privacy" class="section split">
+        <div class="split-copy reveal">
+          <p class="eyebrow">Privacy model</p>
+          <h2>The boundaries, stated plainly.</h2>
+          <p class="sub">
+            Zerm is a voice app with microphone and Accessibility access. That
+            deserves specifics rather than a slogan.
+          </p>
+        </div>
+        <div class="split-visual reveal">
+          <ul class="boundaries">
+            <li><b>Local by default.</b> Audio stays on the machine on the local transcription path.</li>
+            <li><b>Cloud is opt-in.</b> No provider is contacted until you add a key and select it.</li>
+            <li><b>Request storage is separate.</b> Logging AI payloads is its own setting, off from runtime calls.</li>
+            <li><b>Power Mode context is scoped.</b> Active app and URL are read only for workflows you configure.</li>
+            <li><b>Auto-paste needs Accessibility.</b> Decline it and Zerm falls back to the clipboard.</li>
+            <li><b>Auditable.</b> All of the above is in the source, under GPLv3.</li>
+          </ul>
+        </div>
       </section>
 
       <section id="download" class="section">
-        <div class="section-head">
-          <p class="kicker">Downloads</p>
-          <h2>Install the macOS app or compile from source.</h2>
-          <p>
-            Download links are populated directly from the latest release.
-            Current version: <span id="release-tag-2">loading…</span>.
+        <div class="section-head reveal">
+          <p class="eyebrow">Download</p>
+          <h2>Install it, or build it yourself.</h2>
+          <p class="sub">
+            Links resolve straight to the assets of the latest published release —
+            currently <span id="release-tag-2">loading…</span>.
           </p>
         </div>
 
         <div class="download-grid">
-          <a class="download-card featured" data-platform="mac-arm" href="#download">
-            <span>macOS Apple Silicon</span>
+          <a class="card download-card featured reveal" data-platform="mac-arm" href="#download">
+            <span class="dl-kind">macOS · Apple Silicon</span>
             <strong>.dmg</strong>
             <small>M1 and newer</small>
           </a>
-          <a class="download-card" data-platform="mac-x86" href="#download">
-            <span>macOS Intel</span>
-            <strong>.dmg</strong>
-            <small>x86_64</small>
+          <a class="card download-card reveal" data-platform="mac-zip" href="#download">
+            <span class="dl-kind">macOS · archive</span>
+            <strong>.zip</strong>
+            <small>Unzip into /Applications</small>
           </a>
-          <a class="download-card source-card" href="https://github.com/arcusis/Zerm/blob/Production/BUILDING.md">
-            <span>Source</span>
+          <a class="card download-card reveal" href="https://github.com/arcusis/Zerm/blob/Production/BUILDING.md">
+            <span class="dl-kind">Source</span>
             <strong>xcodebuild</strong>
-            <small>Build the Swift macOS app locally</small>
+            <small>Xcode 16 · Swift &amp; SwiftUI</small>
           </a>
         </div>
       </section>
 
-      <section id="origin" class="section attribution">
-        <div class="section-head">
-          <p class="kicker">Origin and license</p>
-          <h2>Based on VoiceInk, credited in public, and licensed under GPLv3.</h2>
-          <p>
-            Zerm is a modified derivative of VoiceInk by Beingpax. VoiceInk
-            provided the foundation for the native macOS dictation workflow,
-            transcription pipeline, Power Mode, model handling, and supporting
-            services. Zerm keeps the GPLv3 license and links back to upstream.
+      <section id="origin" class="section">
+        <div class="section-head reveal">
+          <p class="eyebrow">Origin &amp; license</p>
+          <h2>Built on VoiceInk. Credited in public.</h2>
+          <p class="sub">
+            Zerm is a modified GPLv3 derivative of VoiceInk by Beingpax, which
+            provided the foundation for the macOS app architecture, dictation
+            workflow, transcription pipeline, Power Mode, and model management.
+            The license stays, the attribution stays, and upstream is linked from
+            everywhere it should be.
           </p>
         </div>
-        <div class="attribution-grid">
-          <a href="https://github.com/Beingpax/VoiceInk">
-            <span>Upstream project</span>
+
+        <div class="origin-grid">
+          <a class="card origin-card reveal" href="https://github.com/Beingpax/VoiceInk">
+            <span class="dl-kind">Upstream</span>
             <strong>Beingpax/VoiceInk</strong>
-            <small>Original GPLv3 foundation</small>
+            <small>The original GPLv3 project</small>
           </a>
-          <a href="https://github.com/arcusis/Zerm/blob/Production/NOTICE">
-            <span>Attribution notice</span>
+          <a class="card origin-card reveal" href="https://github.com/arcusis/Zerm/blob/Production/NOTICE">
+            <span class="dl-kind">Attribution</span>
             <strong>NOTICE</strong>
             <small>Migration and modification notes</small>
           </a>
-          <a href="https://github.com/arcusis/Zerm/blob/Production/LICENSE">
-            <span>License</span>
+          <a class="card origin-card reveal" href="https://github.com/arcusis/Zerm/blob/Production/LICENSE">
+            <span class="dl-kind">License</span>
             <strong>GNU GPLv3</strong>
             <small>Source license for Zerm</small>
           </a>
         </div>
       </section>
 
-      <section id="privacy" class="section split">
-        <div class="section-head left">
-          <p class="kicker">Privacy model</p>
-          <h2>Clear boundaries for local and configured services.</h2>
+      <section class="closer reveal">
+        <h2>Read the code. File issues. Send patches.</h2>
+        <p>
+          The repository carries the architecture notes, build instructions, and
+          contributor guidance.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-light btn-lg" href="https://github.com/arcusis/Zerm">
+            <span class="btn-label">Open repository</span>
+            <span class="btn-sub">github.com/arcusis/Zerm</span>
+          </a>
+          <a class="btn btn-dark btn-lg" href="https://github.com/arcusis/Zerm/issues">
+            <span class="btn-label">Issues</span>
+            <span class="btn-sub">Bugs &amp; requests</span>
+          </a>
         </div>
-        <div class="privacy-list">
-          <p>
-            Zerm records through macOS microphone APIs, supports local
-            transcription paths, and only uses cloud or AI providers that the
-            user configures. Context-aware features may require additional
-            macOS permissions so the app can understand where text is going.
-          </p>
-          <ul>
-            <li>Local transcription paths keep audio on the device.</li>
-            <li>Cloud transcription providers require explicit setup.</li>
-            <li>AI request payload storage is controlled separately from runtime requests.</li>
-            <li>Power Mode uses active app and browser context only for configured workflows.</li>
-            <li>macOS auto-paste requires Accessibility permission.</li>
-          </ul>
-        </div>
-      </section>
-
-      <section class="section repo">
-        <div>
-          <p class="kicker">Open source</p>
-          <h2>Read the code, file issues, send patches.</h2>
-          <p>
-            The README includes VoiceInk attribution, GPLv3 licensing,
-            architecture notes, build instructions, and contributor guidance.
-          </p>
-        </div>
-        <a class="button primary" href="https://github.com/arcusis/Zerm">Open repository</a>
       </section>
     </main>
 
     <footer class="site-foot">
-      <span>© <span id="year"></span> Arcusis. GPLv3. Based on VoiceInk by Beingpax.</span>
-      <span class="foot-links">
-        <a href="https://github.com/arcusis/Zerm">Repository</a>
-        <a href="https://github.com/Beingpax/VoiceInk">VoiceInk</a>
-        <a href="#download">Download</a>
-        <a href="https://github.com/arcusis/Zerm/issues">Issues</a>
-      </span>
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="#download">Download</a>
+          <a href="https://github.com/arcusis/Zerm">Repository</a>
+          <a href="https://github.com/arcusis/Zerm/issues">Issues</a>
+          <a href="https://github.com/arcusis/Zerm/wiki">Wiki</a>
+          <a href="https://github.com/Beingpax/VoiceInk">VoiceInk</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
     </footer>
 
     <script src="./site.js" defer></script>

--- a/docs/site.js
+++ b/docs/site.js
@@ -11,9 +11,15 @@
     return assets.find((a) => /x64|x86_64|amd64/i.test(a.name) && /\.dmg$/i.test(a.name));
   }
 
+  // The plain macOS archive, for people who would rather not mount a disk image
+  function assetForZip(assets) {
+    return assets.find((a) => /\.zip$/i.test(a.name) && /mac/i.test(a.name));
+  }
+
   function assetFor(platform, assets) {
     if (platform === "mac-arm") return assetForArm(assets);
     if (platform === "mac-x86") return assetForIntel(assets);
+    if (platform === "mac-zip") return assetForZip(assets);
     return null;
   }
 
@@ -69,7 +75,16 @@
       cards.forEach((card) => {
         const platform = card.getAttribute("data-platform");
         const asset = assetFor(platform, assets);
-        if (!asset?.browser_download_url) return;
+
+        // No build for this platform in the current release — say so rather
+        // than leaving the card pointing at an anchor that goes nowhere.
+        if (!asset?.browser_download_url) {
+          card.classList.add("unavailable");
+          card.href = `https://github.com/${REPO}/releases`;
+          const hint = card.querySelector("small");
+          if (hint) hint.textContent = "Not in this release · see all releases";
+          return;
+        }
 
         card.href = asset.browser_download_url;
         const hint = card.querySelector("small");
@@ -91,7 +106,8 @@
         }
         if (primarySub) {
           const size = formatSize(primaryAsset.size);
-          primarySub.textContent = [tag, primaryAsset.name.includes("aarch64") ? "Apple Silicon" : "Intel", size]
+          const arch = /aarch64|arm64/i.test(primaryAsset.name) ? "Apple Silicon" : "Intel";
+          primarySub.textContent = [tag, arch, size]
             .filter(Boolean)
             .join(" · ");
         }
@@ -109,12 +125,41 @@
     }
   }
 
+  // Fade sections in as they enter the viewport. Degrades to "always visible".
+  function initReveals() {
+    const targets = document.querySelectorAll(".reveal");
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (reduced || !("IntersectionObserver" in window)) {
+      document.body.classList.add("no-reveal");
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          entry.target.classList.add("in");
+          observer.unobserve(entry.target);
+        });
+      },
+      { rootMargin: "0px 0px -8% 0px", threshold: 0.08 }
+    );
+
+    targets.forEach((el) => observer.observe(el));
+  }
+
   const year = document.getElementById("year");
   if (year) year.textContent = new Date().getFullYear();
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", hydrateDownloads);
-  } else {
+  function init() {
+    initReveals();
     hydrateDownloads();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
   }
 })();

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,20 +1,32 @@
+/* Zerm — near-monochrome dark system.
+   Depth comes from surface steps, not shadows. One chromatic signal: record red. */
+
 :root {
-  color-scheme: light;
-  --bg: #f5f7fb;
-  --ink: #171717;
-  --muted: #596170;
-  --quiet: #7c8492;
-  --panel: #ffffff;
-  --panel-2: #eef4ff;
-  --line: #dbe1ea;
-  --line-strong: #b9c4d4;
-  --accent: #e43d36;
-  --accent-dark: #a32522;
-  --blue: #285d8f;
-  --green: #31705d;
-  --shadow: 0 18px 45px rgba(20, 31, 52, 0.13);
-  --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
-  --mono: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  color-scheme: dark;
+
+  --deep: #060607;
+  --canvas: #0b0b0c;
+  --s1: #111112;
+  --s2: #17171a;
+  --s3: #212125;
+  --s4: #2b2b31;
+
+  --line: #232327;
+  --line-soft: #1b1b1f;
+
+  --text: #f3f2f0;
+  --text-2: #9a9aa1;
+  --text-3: #6f6f77;
+
+  --rec: #ff3b30;
+  --rec-text: #ff7a70;
+
+  --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+    "Inter", system-ui, sans-serif;
+  --mono: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, monospace;
+
+  --page: 1160px;
+  --ease: cubic-bezier(0.44, 0, 0.56, 1);
 }
 
 *,
@@ -24,557 +36,1111 @@
 }
 
 html {
-  min-height: 100%;
   scroll-behavior: smooth;
 }
 
 body {
-  min-height: 100%;
   margin: 0;
-  background:
-    linear-gradient(90deg, rgba(23, 23, 23, 0.03) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(23, 23, 23, 0.025) 1px, transparent 1px),
-    var(--bg);
-  background-size: 48px 48px;
-  color: var(--ink);
+  background: var(--canvas);
+  color: var(--text);
   font-family: var(--sans);
-  line-height: 1.5;
-  letter-spacing: 0;
+  font-size: 16px;
+  line-height: 1.55;
+  letter-spacing: -0.011em;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
+}
+
+code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  color: var(--text);
+}
+
+:focus-visible {
+  outline: 2px solid var(--rec-text);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.skip {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip:focus {
+  left: 12px;
+  top: 12px;
+  z-index: 99;
+  padding: 10px 14px;
+  background: var(--text);
+  color: var(--deep);
+  border-radius: 6px;
+}
+
+/* ---------- Chrome ---------- */
+
+.announce {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 9px 20px;
+  background: var(--deep);
+  border-bottom: 1px solid var(--line-soft);
+  color: var(--text-2);
+  font-size: 13px;
+  letter-spacing: -0.005em;
+}
+
+.announce-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--rec);
+  box-shadow: 0 0 0 3px rgba(255, 59, 48, 0.16);
+}
+
+.announce span:not(.announce-dot) {
+  color: var(--text-2);
+}
+
+.announce #release-tag {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.announce a {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--text-3);
+  transition: text-decoration-color 0.15s ease;
+}
+
+.announce a:hover {
+  text-decoration-color: var(--text);
 }
 
 .topbar {
   position: sticky;
   top: 0;
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-  padding: 14px clamp(18px, 4vw, 44px);
-  border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg) 92%, white 8%);
+  z-index: 30;
+  background: rgba(11, 11, 12, 0.72);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 1px solid var(--line-soft);
 }
 
-.brand,
-.topbar-nav,
-.hero-actions,
-.release-line,
-.foot-links {
+.topbar-inner {
+  width: min(var(--page), calc(100% - 40px));
+  margin: 0 auto;
+  height: 60px;
   display: flex;
   align-items: center;
+  gap: 24px;
 }
 
 .brand {
-  gap: 10px;
-  text-decoration: none;
-  font-weight: 720;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
 }
 
 .brand-logo {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
+  border-radius: 7px;
 }
 
 .topbar-nav {
-  gap: clamp(14px, 3vw, 28px);
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  margin-left: auto;
 }
 
 .topbar-nav a,
-.foot-links a {
-  color: var(--muted);
+.ghost-link {
+  color: var(--text-2);
   font-size: 14px;
-  font-weight: 620;
-  text-decoration: none;
+  letter-spacing: -0.01em;
+  transition: color 0.2s var(--ease);
 }
 
 .topbar-nav a:hover,
-.foot-links a:hover {
-  color: var(--ink);
+.ghost-link:hover {
+  color: var(--text);
 }
 
-main {
-  width: min(1180px, calc(100% - 36px));
-  margin: 0 auto;
-}
-
-.hero {
-  min-height: 76vh;
-  display: grid;
-  grid-template-columns: minmax(0, 1.12fr) minmax(320px, 0.88fr);
-  gap: clamp(32px, 6vw, 86px);
+.topbar-actions {
+  display: flex;
   align-items: center;
-  padding: clamp(58px, 9vw, 108px) 0 clamp(42px, 7vw, 72px);
+  gap: 18px;
+  margin-left: auto;
 }
 
-.hero-logo {
-  width: clamp(82px, 11vw, 126px);
-  height: clamp(82px, 11vw, 126px);
-  border-radius: 24px;
-  box-shadow: var(--shadow);
+.topbar-nav + .topbar-actions {
+  margin-left: 0;
 }
 
-.kicker {
-  margin: 0 0 12px;
-  color: var(--accent-dark);
-  font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 760;
-  text-transform: uppercase;
-}
+/* ---------- Buttons ---------- */
 
-.hero h1 {
-  max-width: 760px;
-  margin: 18px 0 18px;
-  font-size: clamp(42px, 7vw, 84px);
-  line-height: 0.98;
-  letter-spacing: 0;
-}
-
-.hero-lede {
-  max-width: 670px;
-  margin: 0;
-  color: var(--muted);
-  font-size: clamp(17px, 2vw, 21px);
-}
-
-.hero-actions {
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 30px;
-}
-
-.button {
-  min-height: 48px;
+.btn {
   display: inline-flex;
-  align-items: center;
+  flex-direction: column;
   justify-content: center;
   border-radius: 8px;
-  padding: 12px 18px;
-  font-weight: 740;
-  text-decoration: none;
-  border: 1px solid var(--line-strong);
+  font-weight: 550;
+  letter-spacing: -0.012em;
+  border: 1px solid transparent;
+  transition: background-color 0.25s var(--ease), border-color 0.25s var(--ease),
+    color 0.25s var(--ease);
 }
 
-.button.primary {
-  flex-direction: column;
-  align-items: flex-start;
-  min-width: 210px;
-  background: var(--ink);
-  border-color: var(--ink);
-  color: var(--panel);
+.btn-sm {
+  padding: 7px 14px;
+  font-size: 14px;
 }
 
-.button.secondary {
-  background: transparent;
-  color: var(--ink);
+.btn-lg {
+  min-width: 198px;
+  padding: 11px 20px;
+  gap: 1px;
 }
 
-.button:hover,
-.download-card:hover {
-  transform: translateY(-2px);
+.btn-light {
+  background: var(--text);
+  color: var(--deep);
+}
+
+.btn-light:hover {
+  background: #ffffff;
+}
+
+.btn-dark {
+  background: var(--s2);
+  border-color: var(--line);
+  color: var(--text);
+}
+
+.btn-dark:hover {
+  background: var(--s3);
+  border-color: var(--s4);
 }
 
 .btn-label {
   font-size: 15px;
+  font-weight: 600;
 }
 
 .btn-sub {
-  color: color-mix(in srgb, var(--panel) 72%, transparent);
   font-family: var(--mono);
   font-size: 11px;
-  font-weight: 520;
-}
-
-.release-line {
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-top: 20px;
-  color: var(--quiet);
-  font-family: var(--mono);
-  font-size: 12px;
-}
-
-.release-line span {
-  padding: 4px 8px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--panel) 68%, transparent);
-}
-
-.workflow-panel {
-  border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: var(--panel);
-  box-shadow: var(--shadow);
-  padding: clamp(20px, 4vw, 34px);
-}
-
-.pill-preview {
-  min-height: 62px;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  width: fit-content;
-  margin-bottom: 28px;
-  padding: 14px 22px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: #151515;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-}
-
-.record-dot {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: var(--accent);
-}
-
-.wave {
-  width: 4px;
-  height: var(--h);
-  border-radius: 3px;
-  background: var(--panel);
-  animation: wave 1.2s ease-in-out infinite;
-}
-
-.wave:nth-of-type(2) { animation-delay: 0.08s; }
-.wave:nth-of-type(3) { animation-delay: 0.16s; }
-.wave:nth-of-type(4) { animation-delay: 0.24s; }
-.wave:nth-of-type(5) { animation-delay: 0.32s; }
-.wave:nth-of-type(6) { animation-delay: 0.40s; }
-
-@keyframes wave {
-  0%, 100% { transform: scaleY(0.72); }
-  50% { transform: scaleY(1.12); }
-}
-
-.workflow-steps {
-  display: grid;
-  gap: 14px;
-}
-
-.workflow-steps div {
-  display: grid;
-  grid-template-columns: 42px 1fr;
-  gap: 8px 14px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid var(--line);
-}
-
-.workflow-steps div:last-child {
-  border-bottom: 0;
-  padding-bottom: 0;
-}
-
-.workflow-steps span {
-  grid-row: span 2;
-  color: var(--accent-dark);
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 760;
-}
-
-.workflow-steps strong {
-  font-size: 17px;
-}
-
-.workflow-steps p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 14px;
-}
-
-.strip {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: var(--ink);
-  color: var(--panel);
-  overflow: hidden;
-}
-
-.strip div {
-  min-height: 118px;
-  padding: 22px;
-  border-right: 1px solid rgba(255, 255, 255, 0.14);
-}
-
-.strip div:last-child {
-  border-right: 0;
-}
-
-.strip strong,
-.strip span {
-  display: block;
-}
-
-.strip strong {
-  margin-bottom: 8px;
-  font-size: 18px;
-}
-
-.strip span {
-  color: rgba(255, 252, 244, 0.72);
-  font-size: 14px;
-}
-
-.section {
-  padding: clamp(68px, 10vw, 112px) 0 0;
-}
-
-.section-head {
-  max-width: 690px;
-  margin-bottom: 28px;
-}
-
-.section-head.left {
-  margin-bottom: 0;
-}
-
-.section h2 {
-  margin: 0 0 14px;
-  font-size: clamp(30px, 5vw, 52px);
-  line-height: 1;
+  font-weight: 400;
   letter-spacing: 0;
-}
-
-.section-head p:not(.kicker),
-.repo p,
-.privacy-list {
-  color: var(--muted);
-  font-size: 16px;
-}
-
-.download-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-}
-
-.download-card {
-  min-height: 145px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 18px;
-  border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: var(--panel);
-  color: inherit;
-  text-decoration: none;
-  box-shadow: 0 10px 24px rgba(37, 31, 21, 0.08);
-  transition: transform 160ms ease, border-color 160ms ease;
-}
-
-.download-card:hover {
-  border-color: var(--accent);
-}
-
-.download-card span,
-.download-card small {
-  color: var(--muted);
-}
-
-.download-card strong {
-  font-size: 22px;
-  line-height: 1.08;
-}
-
-.download-card small {
-  font-family: var(--mono);
-  font-size: 12px;
-}
-
-.source-card {
-  background: var(--panel-2);
-}
-
-.native-layer,
-.attribution {
-  scroll-margin-top: 72px;
-}
-
-.native-grid,
-.attribution-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-}
-
-.native-grid div,
-.attribution-grid a {
-  display: flex;
-  min-height: 220px;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 14px;
-  padding: 20px;
-  border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: var(--panel);
-  box-shadow: 0 10px 24px rgba(37, 31, 21, 0.08);
-}
-
-.attribution-grid a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.native-grid span,
-.attribution-grid span {
-  color: var(--accent-dark);
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 760;
-}
-
-.native-grid strong,
-.attribution-grid strong {
-  font-size: 21px;
-  line-height: 1.08;
-}
-
-.native-grid p,
-.attribution-grid small {
-  margin: 0;
-  color: var(--muted);
-  font-size: 14px;
+  opacity: 0.62;
 }
 
 .text-link {
-  display: inline-flex;
-  margin-top: 18px;
-  color: var(--accent-dark);
-  font-weight: 740;
-  text-decoration: underline;
-  text-underline-offset: 4px;
+  display: inline-block;
+  margin-top: 26px;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 550;
+  border-bottom: 1px solid var(--text-3);
+  padding-bottom: 2px;
+  transition: border-color 0.2s var(--ease);
 }
 
-.split {
+.text-link:hover {
+  border-color: var(--text);
+}
+
+/* ---------- Type ---------- */
+
+.eyebrow {
+  margin: 0 0 18px;
+  color: var(--rec-text);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(38px, 5.6vw, 62px);
+  font-weight: 600;
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+h2 {
+  margin: 0 0 16px;
+  font-size: clamp(28px, 4vw, 42px);
+  font-weight: 600;
+  line-height: 1.06;
+  letter-spacing: -0.032em;
+}
+
+h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.lede {
+  max-width: 36em;
+  margin: 22px 0 0;
+  color: var(--text-2);
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+.sub {
+  max-width: 40em;
+  margin: 0;
+  color: var(--text-2);
+  font-size: 16px;
+}
+
+/* ---------- Layout ---------- */
+
+main {
+  width: min(var(--page), calc(100% - 40px));
+  margin: 0 auto;
+}
+
+.section {
+  padding: clamp(72px, 10vw, 128px) 0 0;
+  scroll-margin-top: 80px;
+}
+
+.section-head {
+  max-width: 660px;
+  margin-bottom: 40px;
+}
+
+/* ---------- Hero ---------- */
+
+.hero {
   display: grid;
-  grid-template-columns: 0.9fr 1.1fr;
-  gap: clamp(28px, 6vw, 74px);
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+  gap: clamp(36px, 5vw, 72px);
+  align-items: center;
+  padding: clamp(56px, 9vw, 104px) 0 clamp(48px, 7vw, 80px);
 }
 
-.privacy-list p {
-  margin-top: 0;
-}
-
-.privacy-list ul {
-  display: grid;
-  gap: 10px;
-  margin: 20px 0 0;
-  padding-left: 20px;
-}
-
-.repo {
+.hero-actions {
   display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 28px;
-  padding-bottom: clamp(72px, 10vw, 120px);
-}
-
-.repo div {
-  max-width: 690px;
-}
-
-.site-foot {
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
   flex-wrap: wrap;
-  padding: 24px clamp(18px, 4vw, 44px);
-  border-top: 1px solid var(--line);
-  color: var(--muted);
+  gap: 12px;
+  margin-top: 34px;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 26px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.hero-meta li {
+  padding: 5px 11px;
+  border: 1px solid var(--line);
+  border-radius: 200px;
+  background: var(--s1);
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0;
+}
+
+/* ---------- Hero product object ---------- */
+
+.window {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--s1);
+  overflow: hidden;
+}
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--s2);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--s4);
+}
+
+.dot-r { background: #4a2a28; }
+.dot-y { background: #4a3f26; }
+.dot-g { background: #29401f; }
+
+.window-title {
+  margin-left: 8px;
+  color: var(--text-3);
+  font-size: 12px;
+  letter-spacing: -0.005em;
+}
+
+.window-body {
+  padding: 26px 22px 18px;
+}
+
+.pill {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: fit-content;
+  margin: 0 auto;
+  padding: 12px 20px;
+  border: 1px solid #2a2a2e;
+  border-radius: 999px;
+  background: #000;
+}
+
+.rec {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--rec);
+  animation: pulse 2s var(--ease) infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+.wave {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 30px;
+}
+
+.wave i {
+  width: 3px;
+  height: var(--h);
+  border-radius: 2px;
+  background: var(--text);
+  opacity: 0.85;
+  animation: wave 1.15s var(--ease) infinite;
+}
+
+.wave i:nth-child(2) { animation-delay: 0.07s; }
+.wave i:nth-child(3) { animation-delay: 0.14s; }
+.wave i:nth-child(4) { animation-delay: 0.21s; }
+.wave i:nth-child(5) { animation-delay: 0.28s; }
+.wave i:nth-child(6) { animation-delay: 0.35s; }
+.wave i:nth-child(7) { animation-delay: 0.42s; }
+.wave i:nth-child(8) { animation-delay: 0.49s; }
+.wave i:nth-child(9) { animation-delay: 0.56s; }
+
+@keyframes wave {
+  0%, 100% { transform: scaleY(0.55); }
+  50% { transform: scaleY(1.15); }
+}
+
+.pill-time {
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.cue {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 18px 0 24px;
+  color: var(--text-3);
+  font-size: 12.5px;
+}
+
+.cue span {
+  margin-left: 4px;
+}
+
+kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  background: var(--s3);
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.transcript {
+  padding: 16px 18px;
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  background: var(--s2);
+}
+
+.transcript p {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: -0.014em;
+}
+
+.caret {
+  display: inline-block;
+  width: 2px;
+  height: 1.05em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--rec);
+  animation: blink 1.1s steps(1) infinite;
+}
+
+@keyframes blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+.window-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.window-foot b {
+  color: var(--text-2);
+  font-weight: 500;
+}
+
+.sep {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--s4);
+}
+
+/* ---------- Runtime strip ---------- */
+
+.logostrip {
+  display: flex;
+  align-items: center;
+  gap: clamp(20px, 4vw, 44px);
+  flex-wrap: wrap;
+  padding: 26px 0;
+  border-top: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.logostrip p {
+  margin: 0;
+  color: var(--text-3);
   font-size: 13px;
 }
 
+.logostrip ul {
+  display: flex;
+  gap: clamp(18px, 3vw, 34px);
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.logostrip li {
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: -0.01em;
+}
+
+/* ---------- Cards ---------- */
+
+.card {
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--s1);
+  transition: background-color 0.3s var(--ease), border-color 0.3s var(--ease);
+}
+
+.card p {
+  margin: 10px 0 0;
+  color: var(--text-2);
+  font-size: 14.5px;
+  line-height: 1.55;
+}
+
+.model-grid,
+.feature-grid,
+.download-grid,
+.origin-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.model-grid,
+.download-grid,
+.origin-grid {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.feature-grid {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.model-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 268px;
+  padding: 26px;
+}
+
+.card-idx {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+}
+
+.model-card h3 {
+  margin-top: 20px;
+  font-size: 24px;
+  letter-spacing: -0.028em;
+}
+
+.card-role {
+  margin: 4px 0 0 !important;
+  color: var(--rec-text) !important;
+  font-family: var(--mono);
+  font-size: 12px !important;
+  letter-spacing: 0.02em;
+}
+
+.model-card p:last-of-type {
+  flex: 1;
+}
+
+.tag {
+  align-self: flex-start;
+  margin-top: 20px;
+  padding: 4px 10px;
+  border-radius: 200px;
+  background: var(--s3);
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.card:hover {
+  background: var(--s2);
+  border-color: var(--s4);
+}
+
+/* ---------- Split sections ---------- */
+
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(32px, 5vw, 72px);
+  align-items: center;
+}
+
+.split.reverse .split-copy {
+  order: 2;
+}
+
+.steps {
+  margin: 30px 0 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: step;
+}
+
+.steps li {
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  gap: 4px 12px;
+  padding: 16px 0;
+  border-top: 1px solid var(--line-soft);
+  counter-increment: step;
+}
+
+.steps li::before {
+  content: "0" counter(step);
+  grid-row: span 2;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 12px;
+  padding-top: 2px;
+}
+
+.steps b {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.steps span {
+  color: var(--text-2);
+  font-size: 14.5px;
+}
+
+.checks {
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.checks li {
+  position: relative;
+  padding: 12px 0 12px 26px;
+  border-top: 1px solid var(--line-soft);
+  color: var(--text-2);
+  font-size: 15px;
+}
+
+.checks li::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 20px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--rec);
+  opacity: 0.7;
+}
+
+.panel {
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--s1);
+}
+
+.panel-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 14px;
+  border-radius: 9px;
+  transition: background-color 0.3s var(--ease);
+}
+
+.panel-row:hover {
+  background: var(--s2);
+}
+
+.panel-row + .panel-row {
+  border-top: 1px solid var(--line-soft);
+  border-radius: 9px;
+}
+
+.panel-key {
+  display: flex;
+  gap: 4px;
+  min-width: 108px;
+}
+
+.panel-label {
+  color: var(--text-2);
+  font-size: 14.5px;
+}
+
+.panel-row.muted .panel-label {
+  color: var(--text-3);
+}
+
+/* Read aloud panel */
+
+.read-panel {
+  padding: 22px;
+}
+
+.read-source,
+.read-out {
+  margin: 0;
+  padding: 16px 18px;
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  background: var(--s2);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.read-source {
+  color: var(--text-2);
+}
+
+.read-source mark {
+  background: rgba(255, 59, 48, 0.14);
+  color: var(--rec-text);
+  border-radius: 3px;
+  padding: 0 3px;
+}
+
+.read-out {
+  color: var(--text);
+}
+
+.read-arrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 2px;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.read-arrow::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
+.speaker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.speaker-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--s3);
+  border: 1px solid var(--line);
+}
+
+.speaker-bars {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 18px;
+}
+
+.speaker-bars i {
+  width: 3px;
+  height: 60%;
+  border-radius: 2px;
+  background: var(--text-3);
+  animation: wave 1.4s var(--ease) infinite;
+}
+
+.speaker-bars i:nth-child(2) { animation-delay: 0.1s; }
+.speaker-bars i:nth-child(3) { animation-delay: 0.2s; }
+.speaker-bars i:nth-child(4) { animation-delay: 0.3s; }
+.speaker-bars i:nth-child(5) { animation-delay: 0.4s; }
+
+.speaker-name {
+  margin-left: auto;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+/* ---------- Privacy ---------- */
+
+.boundaries {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--s1);
+  overflow: hidden;
+}
+
+.boundaries li {
+  padding: 16px 20px;
+  color: var(--text-2);
+  font-size: 14.5px;
+  line-height: 1.55;
+}
+
+.boundaries li + li {
+  border-top: 1px solid var(--line-soft);
+}
+
+.boundaries b {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---------- Download & origin ---------- */
+
+.download-card,
+.origin-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 156px;
+}
+
+.dl-kind {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+}
+
+.download-card strong,
+.origin-card strong {
+  margin-top: auto;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.028em;
+}
+
+.download-card small,
+.origin-card small {
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.download-card.featured {
+  background: var(--s2);
+  border-color: var(--s4);
+}
+
+.download-card.unavailable strong,
+.download-card.unavailable .dl-kind {
+  color: var(--text-3);
+}
+
+.download-card.featured .dl-kind {
+  color: var(--rec-text);
+}
+
+/* ---------- Closer ---------- */
+
+.closer {
+  margin-top: clamp(72px, 10vw, 128px);
+  padding: clamp(48px, 6vw, 76px) clamp(28px, 5vw, 64px);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: linear-gradient(180deg, var(--s2) 0%, var(--s1) 100%);
+}
+
+.closer h2 {
+  max-width: 15em;
+}
+
+.closer p {
+  max-width: 40em;
+  margin: 0;
+  color: var(--text-2);
+}
+
+/* ---------- Footer ---------- */
+
+.site-foot {
+  margin-top: clamp(72px, 10vw, 120px);
+  border-top: 1px solid var(--line-soft);
+  background: var(--deep);
+}
+
+.foot-inner {
+  width: min(var(--page), calc(100% - 40px));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 20px 32px;
+  flex-wrap: wrap;
+  padding: 28px 0;
+}
+
+.foot-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.foot-brand img {
+  border-radius: 6px;
+}
+
 .foot-links {
-  gap: 18px;
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+}
+
+.foot-links a {
+  color: var(--text-2);
+  font-size: 13.5px;
+  transition: color 0.2s var(--ease);
+}
+
+.foot-links a:hover {
+  color: var(--text);
+}
+
+.foot-legal {
+  margin: 0 0 0 auto;
+  color: var(--text-3);
+  font-size: 12.5px;
+}
+
+/* ---------- Reveal ---------- */
+
+.reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
+}
+
+.reveal.in,
+.no-reveal .reveal {
+  opacity: 1;
+  transform: none;
+}
+
+.model-grid .reveal.in:nth-child(2),
+.feature-grid .reveal.in:nth-child(2),
+.download-grid .reveal.in:nth-child(2),
+.origin-grid .reveal.in:nth-child(2) {
+  transition-delay: 0.07s;
+}
+
+.model-grid .reveal.in:nth-child(3),
+.feature-grid .reveal.in:nth-child(3),
+.download-grid .reveal.in:nth-child(3),
+.origin-grid .reveal.in:nth-child(3) {
+  transition-delay: 0.14s;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 1000px) {
+  .feature-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .topbar-nav {
+    display: none;
+  }
+
+  /* the adjacency rule above still matches a hidden nav — restore the push */
+  .topbar-nav + .topbar-actions {
+    margin-left: auto;
+  }
 }
 
 @media (max-width: 860px) {
   .hero,
-  .split,
-  .repo {
+  .split {
     grid-template-columns: 1fr;
   }
 
-  .workflow-panel {
-    max-width: 520px;
+  .split.reverse .split-copy {
+    order: 0;
   }
 
-  .strip,
+  .model-grid,
   .download-grid,
-  .native-grid,
-  .attribution-grid {
+  .origin-grid {
     grid-template-columns: 1fr;
   }
 
-  .strip div {
-    border-right: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+  .model-card {
+    min-height: 0;
   }
 
-  .strip div:last-child {
-    border-bottom: 0;
-  }
-
-  .repo {
-    align-items: start;
+  .hero-stage {
+    max-width: 560px;
   }
 }
 
-@media (max-width: 560px) {
-  main {
-    width: min(100% - 28px, 1180px);
+@media (max-width: 620px) {
+  main,
+  .topbar-inner,
+  .foot-inner {
+    width: min(100% - 32px, var(--page));
   }
 
-  .topbar {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .btn-lg {
+    width: 100%;
+    min-width: 0;
     align-items: flex-start;
   }
 
-  .topbar-nav {
-    gap: 10px;
-    flex-wrap: wrap;
-    justify-content: flex-end;
+  .announce {
+    font-size: 12px;
   }
 
-  .topbar-nav a {
-    font-size: 13px;
+  .foot-legal {
+    margin-left: 0;
   }
 
-  .hero {
-    min-height: auto;
-    padding-top: 42px;
-  }
-
-  .hero h1 {
-    font-size: clamp(38px, 14vw, 58px);
-  }
-
-  .button.primary,
-  .button.secondary {
-    width: 100%;
+  .logostrip {
+    gap: 14px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
   *,
   *::before,
   *::after {
     animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+  }
+
+  .reveal {
+    opacity: 1;
+    transform: none;
   }
 }


### PR DESCRIPTION
Rebuilds `docs/` as a dark, near-monochrome system. Depth comes from surface colour steps rather than shadows, with record red as the only chromatic accent — taken from the app icon. The hero recorder pill and macOS window chrome are built in CSS, since the repo carries no screenshots to use.

## Content

Leads with Whisper / Kokoro / Gemma instead of the old generic record-transcribe-paste flow, and gives Read Aloud, Smart Reading, and the privacy boundaries their own sections.

## Fixes carried by the old page

- **The "macOS Intel" download card was a permanent dead link.** No release has ever shipped an x86_64 DMG, so the card sat pointing at `#download`. Replaced with the `.zip` archive, which does exist, plus handling that marks any platform missing from a release rather than silently linking nowhere.
- **The primary CTA mislabelled ARM builds as "Intel"** whenever the asset was named `arm64` rather than `aarch64`.
- **The illustrated keyboard shortcuts were invented.** Dictation actually defaults to right Command in hybrid mode, and read aloud ships unassigned — the page now reflects that.

## Verification

Headless Chromium at 1440 / 960 / 390px:

- no console or page errors
- no horizontal overflow
- no broken anchors
- GitHub release hydration resolving to real v2.6.1 assets on both download cards
- reduced-motion respected; scroll reveals degrade to always-visible without JS