### PR TITLE
Host release notes and project docs on the site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ on:
         required: true
         type: string
 
+  # Keep the published changelog in step with GitHub Releases
+  release:
+    types: [published, edited, released, deleted]
+
 permissions:
   contents: write
 
@@ -60,3 +64,32 @@ jobs:
             echo "Upload a DMG with:"
             echo "  gh release upload $TAG path/to/Zerm_VERSION_aarch64.dmg"
           fi
+
+  publish-changelog:
+    name: Regenerate site changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: Production
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Regenerate derived pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/build-site.mjs
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet -- docs/; then
+            echo "No changelog changes."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          git commit -m "Regenerate site changelog from releases"
+          git push origin HEAD:Production

--- a/Makefile
+++ b/Makefile
@@ -178,3 +178,6 @@ help:
 	@echo "  all                Run full build process (default)"
 	@echo "  clean              Remove build artifacts"
 	@echo "  help               Show this help message"
+# Regenerate the derived site pages (changelog, notice, license, building)
+site:
+	node scripts/build-site.mjs

--- a/docs/building.html
+++ b/docs/building.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Build from source — Zerm</title>
+    <meta name="description" content="Requirements, build commands, and release tooling for the native macOS app." />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="Build from source — Zerm" />
+    <meta property="og:description" content="Requirements, build commands, and release tooling for the native macOS app." />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="./#models">Models</a>
+          <a href="./#dictation">Dictation</a>
+          <a href="./#read-aloud">Read aloud</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./changelog.html">Changelog</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="page">
+      <section class="page-hero">
+        <p class="eyebrow">For developers</p>
+        <h1>Build from source</h1>
+        <p class="lede">Requirements, build commands, and release tooling for the native macOS app.</p>
+      </section>
+      <section class="doc"><div class="prose">
+<h1 dir="auto">Building Zerm</h1>
+<p dir="auto">This guide provides detailed instructions for building Zerm from source.</p>
+<h2 dir="auto">Prerequisites</h2>
+<p dir="auto">Before you begin, ensure you have:</p>
+<ul dir="auto">
+<li>macOS 14.4 or later</li>
+<li>Xcode (latest version recommended)</li>
+<li>Swift (latest version recommended)</li>
+<li>Git (for cloning repositories)</li>
+</ul>
+<h2 dir="auto">Quick Start with Makefile (Recommended)</h2>
+<p dir="auto">The easiest way to build Zerm is using the included Makefile, which automates the entire build process including building and linking the whisper framework.</p>
+<h3 dir="auto">Simple Build Commands</h3>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate"><span class="pl-c"><span class="pl-c">#</span> Clone the repository</span>
+git clone https://github.com/Arcusis/Zerm.git
+<span class="pl-c1">cd</span> Zerm
+
+<span class="pl-c"><span class="pl-c">#</span> Build everything (recommended for first-time setup)</span>
+make all
+
+<span class="pl-c"><span class="pl-c">#</span> Or for development (build and run)</span>
+make dev</pre></div>
+<h3 dir="auto">Available Makefile Commands</h3>
+<ul dir="auto">
+<li><code class="notranslate">make check</code> or <code class="notranslate">make healthcheck</code> - Verify all required tools are installed</li>
+<li><code class="notranslate">make whisper</code> - Clone and build whisper.cpp XCFramework automatically</li>
+<li><code class="notranslate">make setup</code> - Prepare the whisper framework for linking</li>
+<li><code class="notranslate">make build</code> - Build the Zerm Xcode project</li>
+<li><code class="notranslate">make local</code> - Build for local use (no Apple Developer certificate needed)</li>
+<li><code class="notranslate">make release</code> - Build the Developer ID signed + notarized release DMG (maintainers only)</li>
+<li><code class="notranslate">make run</code> - Launch the built Zerm app</li>
+<li><code class="notranslate">make dev</code> - Build and run (ideal for development workflow)</li>
+<li><code class="notranslate">make all</code> - Complete build process (default)</li>
+<li><code class="notranslate">make clean</code> - Remove build artifacts and dependencies</li>
+<li><code class="notranslate">make help</code> - Show all available commands</li>
+</ul>
+<h3 dir="auto">How the Makefile Helps</h3>
+<p dir="auto">The Makefile automatically:</p>
+<ol dir="auto">
+<li><strong>Manages Dependencies</strong>: Creates a dedicated <code class="notranslate">~/Zerm-Dependencies</code> directory for all external frameworks</li>
+<li><strong>Builds Whisper Framework</strong>: Clones whisper.cpp and builds the XCFramework with the correct configuration</li>
+<li><strong>Handles Framework Linking</strong>: Sets up the whisper.xcframework in the proper location for Xcode to find</li>
+<li><strong>Verifies Prerequisites</strong>: Checks that git, xcodebuild, and swift are installed before building</li>
+<li><strong>Streamlines Development</strong>: Provides convenient shortcuts for common development tasks</li>
+</ol>
+<p dir="auto">This approach ensures consistent builds across different machines and eliminates manual framework setup errors.</p>
+<hr>
+<h2 dir="auto">Building for Local Use (No Apple Developer Certificate)</h2>
+<p dir="auto">If you don't have an Apple Developer certificate, use <code class="notranslate">make local</code>:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">git clone https://github.com/Arcusis/Zerm.git
+<span class="pl-c1">cd</span> Zerm
+make <span class="pl-k">local</span>
+open <span class="pl-k">~</span>/Downloads/Zerm.app</pre></div>
+<p dir="auto">This builds Zerm with ad-hoc signing using a separate build configuration (<code class="notranslate">LocalBuild.xcconfig</code>) that requires no Apple Developer account.</p>
+<h3 dir="auto">How It Works</h3>
+<p dir="auto">The <code class="notranslate">make local</code> command uses:</p>
+<ul dir="auto">
+<li><code class="notranslate">LocalBuild.xcconfig</code> to override signing and entitlements settings</li>
+<li><code class="notranslate">Zerm.local.entitlements</code> (stripped-down, no CloudKit/keychain groups)</li>
+<li><code class="notranslate">LOCAL_BUILD</code> Swift compilation flag for conditional code paths</li>
+</ul>
+<p dir="auto">Your normal <code class="notranslate">make all</code> / <code class="notranslate">make build</code> commands are completely unaffected.</p>
+<hr>
+<h2 dir="auto">Building a Release (Maintainers)</h2>
+<p dir="auto">Public DMGs must be Developer ID signed <strong>and notarized</strong>, otherwise Gatekeeper<br>
+rejects the app on other Macs ("Zerm is damaged and can't be opened" /<br>
+"Apple could not verify Zerm is free of malware").</p>
+<p dir="auto">Requirements on the release machine:</p>
+<ul dir="auto">
+<li>The <code class="notranslate">Developer ID Application: Arcusis LTD (F9Z784RA6D)</code> certificate in the login keychain</li>
+<li>One-time notarization credential setup:</li>
+</ul>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">xcrun notarytool store-credentials zerm-notary \
+  --key <span class="pl-k">~</span>/.appstoreconnect/private_keys/AuthKey_<span class="pl-k">&lt;</span>KEY-ID<span class="pl-k">&gt;</span>.p8 \
+  --key-id <span class="pl-k">&lt;</span>KEY-ID<span class="pl-k">&gt;</span> \
+  --issuer <span class="pl-k">&lt;</span>ISSUER-UUID<span class="pl-k">&gt;</span></pre></div>
+<p dir="auto">The issuer UUID is shown in App Store Connect under<br>
+<strong>Users and Access → Integrations → App Store Connect API</strong>.</p>
+<p dir="auto">Then build the release:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">make release            <span class="pl-c"><span class="pl-c">#</span> or: scripts/release.sh</span></pre></div>
+<p dir="auto">This builds the Release configuration, signs the app with Developer ID and the<br>
+hardened runtime, notarizes app and DMG with Apple, staples the tickets, and<br>
+verifies the result with <code class="notranslate">spctl</code>. The DMG lands in the repo root as<br>
+<code class="notranslate">Zerm_X.Y.Z_aarch64.dmg</code>, ready for <code class="notranslate">gh release upload</code>.</p>
+<p dir="auto"><code class="notranslate">SKIP_NOTARIZE=1 scripts/release.sh</code> does a signing-only dry run.</p>
+<hr>
+<h2 dir="auto">Manual Build Process (Alternative)</h2>
+<p dir="auto">If you prefer to build manually or need more control over the build process, follow these steps:</p>
+<h3 dir="auto">Building whisper.cpp Framework</h3>
+<ol dir="auto">
+<li>Clone and build whisper.cpp:</li>
+</ol>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">git clone https://github.com/ggerganov/whisper.cpp.git
+<span class="pl-c1">cd</span> whisper.cpp
+./build-xcframework.sh</pre></div>
+<p dir="auto">This will create the XCFramework at <code class="notranslate">build-apple/whisper.xcframework</code>.</p>
+<h3 dir="auto">Building Zerm</h3>
+<ol dir="auto">
+<li>Clone the Zerm repository:</li>
+</ol>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">git clone https://github.com/Arcusis/Zerm.git
+<span class="pl-c1">cd</span> Zerm</pre></div>
+<ol start="2" dir="auto">
+<li>
+<p dir="auto">Add the whisper.xcframework to your project:</p>
+<ul dir="auto">
+<li>Drag and drop <code class="notranslate">../whisper.cpp/build-apple/whisper.xcframework</code> into the project navigator, or</li>
+<li>Add it manually in the "Frameworks, Libraries, and Embedded Content" section of project settings</li>
+</ul>
+</li>
+<li>
+<p dir="auto">Build and Run</p>
+<ul dir="auto">
+<li>Build the project using Cmd+B or Product &gt; Build</li>
+<li>Run the project using Cmd+R or Product &gt; Run</li>
+</ul>
+</li>
+</ol>
+<h2 dir="auto">Development Setup</h2>
+<ol dir="auto">
+<li>
+<p dir="auto"><strong>Xcode Configuration</strong></p>
+<ul dir="auto">
+<li>Ensure you have the latest Xcode version</li>
+<li>Install any required Xcode Command Line Tools</li>
+</ul>
+</li>
+<li>
+<p dir="auto"><strong>Dependencies</strong></p>
+<ul dir="auto">
+<li>The project uses <a href="https://github.com/ggerganov/whisper.cpp" rel="noopener noreferrer" target="_blank">whisper.cpp</a> for transcription</li>
+<li>Ensure the whisper.xcframework is properly linked in your Xcode project</li>
+<li>Test the whisper.cpp installation independently before proceeding</li>
+</ul>
+</li>
+<li>
+<p dir="auto"><strong>Building for Development</strong></p>
+<ul dir="auto">
+<li>Use the Debug configuration for development</li>
+<li>Enable relevant debugging options in Xcode</li>
+</ul>
+</li>
+<li>
+<p dir="auto"><strong>Testing</strong></p>
+<ul dir="auto">
+<li>Run the test suite before making changes</li>
+<li>Ensure all tests pass after your modifications</li>
+</ul>
+</li>
+</ol>
+<h2 dir="auto">Troubleshooting</h2>
+<p dir="auto">If you encounter any build issues:</p>
+<ol dir="auto">
+<li>Clean the build folder (Cmd+Shift+K)</li>
+<li>Clean the build cache (Cmd+Shift+K twice)</li>
+<li>Check Xcode and macOS versions</li>
+<li>Verify all dependencies are properly installed</li>
+<li>Make sure whisper.xcframework is properly built and linked</li>
+</ol>
+<p dir="auto">For more help, please check the <a href="https://github.com/Arcusis/Zerm/issues" rel="noopener noreferrer" target="_blank">issues</a> section or create a new issue.</p>
+      </div></section>
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,922 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Changelog — Zerm</title>
+    <meta name="description" content="Every published Zerm release, with the full notes: what changed, what was fixed, and how much faster it got." />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="Changelog — Zerm" />
+    <meta property="og:description" content="Every published Zerm release, with the full notes: what changed, what was fixed, and how much faster it got." />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="./#models">Models</a>
+          <a href="./#dictation">Dictation</a>
+          <a href="./#read-aloud">Read aloud</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./changelog.html" aria-current="page">Changelog</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="page">
+      <section class="page-hero">
+        <p class="eyebrow">25 releases</p>
+        <h1>Changelog</h1>
+        <p class="lede">Every published release, in full. Newest first.</p>
+      </section>
+      <section class="rel-list">
+        <article class="rel" id="v2.6.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.6.1">v2.6.1</a>
+            <time>27 July 2026</time>
+            <span class="rel-badge now">Latest</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.6.1/Zerm_2.6.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.6.1</h2>
+            <div class="prose">
+<p dir="auto">Fixes three things that made the app feel broken, plus a large latency cut.</p>
+<h3 dir="auto">Fixed</h3>
+<ul dir="auto">
+<li><strong>Shortcut recording did not work anywhere in the app.</strong> Pressing the modifier you wanted to bind fired Zerm's own hotkey instead, which could raise an invisible modal sheet and deadlock the app. Zerm's triggers now stand down while you are recording a shortcut.</li>
+<li><strong>Read Aloud could stop working for an entire session.</strong> Left and right Option were indistinguishable, so the key-state tracking could stick 'pressed' and never fire again.</li>
+<li><strong>Quitting the app crashed</strong> with an abort in the Metal teardown of the speech engine.</li>
+<li>Unsigned/local builds crashed at launch in CloudKit.</li>
+<li>An empty AI enhancement no longer replaces your transcript with nothing.</li>
+<li>With language set to Auto, the Whisper initial prompt is no longer silently discarded.</li>
+</ul>
+<h3 dir="auto">Faster</h3>
+<markdown-accessiblity-table><table role="table">
+<thead>
+<tr>
+<th></th>
+<th>before</th>
+<th>after</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>hotkey → recording</td>
+<td>431 ms</td>
+<td>79–86 ms</td>
+</tr>
+<tr>
+<td>stop → transcription starts</td>
+<td>270–449 ms</td>
+<td>20–42 ms</td>
+</tr>
+<tr>
+<td>dictation after a &gt;2 min gap</td>
+<td>~800 ms model reload</td>
+<td>none</td>
+</tr>
+</tbody>
+</table></markdown-accessiblity-table>
+<p dir="auto">Read Aloud starts sooner and no longer stalls after the first sentence. The on-device language model is no longer loaded at launch, cutting several GB of idle memory.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.5.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.5.1">v2.5.1</a>
+            <time>18 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.5.1/Zerm_2.5.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.5.1</h2>
+            <div class="prose">
+<h2 dir="auto">A cleaner menu bar</h2>
+<ul dir="auto">
+<li><strong>New tray icon.</strong> The menu bar now shows the Zerm microphone — the same glyph as the app icon — rendered as a template image, so it stays crisp on both light and dark menu bars.</li>
+<li><strong>Decluttered tray menu.</strong> The model, prompt, AI provider, AI model, language, and audio-input pickers no longer crowd the menu; all of them remain available in the main window. The menu keeps quick actions: Toggle Recorder, AI Enhancement, Retry/Copy Last Transcription, History, and Settings.</li>
+</ul>
+<hr>
+<p dir="auto"><strong>Install:</strong> download the DMG, drag Zerm to Applications. The app is Developer ID signed and notarized. Existing users on 2.4.0+ will be offered this update automatically.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.5.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.5.0">v2.5.0</a>
+            <time>17 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.5.0/Zerm_2.5.0_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.5.0</h2>
+            <div class="prose">
+<h2 dir="auto">Smarter on every Mac</h2>
+<ul dir="auto">
+<li><strong>Hardware-aware model recommendations.</strong> Zerm now rates your Mac (chip + memory) and tunes the Recommended model list to it. Models that would strain your machine show a clear warning, and models that need more memory than your Mac can spare can no longer be installed.</li>
+<li><strong>Faster, cooler local transcription.</strong> Whisper now runs on your Mac's performance cores only (efficiency cores were slowing it down), and automatically backs off under Low Power Mode or thermal pressure.</li>
+<li><strong>Less battery drain.</strong> Model prewarming now skips Low Power Mode and brief lid-close cycles, and the recording audio meter uses half the wakeups — visually identical.</li>
+</ul>
+<h2 dir="auto">Permissions that just work</h2>
+<ul dir="auto">
+<li>The Permissions screen now detects when macOS has granted Screen Recording but needs a relaunch, and offers a one-click "Quit Zerm to Finish".</li>
+<li>Permission cards refresh automatically after you return from System Settings.</li>
+<li>Enabling Accessibility now shows the proper system prompt so the grant sticks to the right binary.</li>
+</ul>
+<hr>
+<p dir="auto"><strong>Install:</strong> download the DMG, drag Zerm to Applications. The app is Developer ID signed and notarized. Existing users on 2.4.0+ will be offered this update automatically.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.4.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.4.0">v2.4.0</a>
+            <time>17 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.4.0/Zerm_2.4.0_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.4.0</h2>
+            <div class="prose">
+<h2 dir="auto">What's new</h2>
+<p dir="auto"><strong>Sidebar</strong></p>
+<ul dir="auto">
+<li>Renamed the <strong>AI Models</strong> tab to <strong>Dictation Models</strong> (it manages your speech-to-text models — Read Aloud has its own).</li>
+<li>Removed the unused <strong>Transcribe Audio</strong> tab.</li>
+</ul>
+<p dir="auto"><strong>Transcription models</strong></p>
+<ul dir="auto">
+<li>Dropped slow, outdated local models and added a compact <strong>Small</strong> option.</li>
+<li>Refreshed cloud models and <strong>added OpenAI and AssemblyAI</strong> as new providers.</li>
+</ul>
+<p dir="auto"><strong>Enhancement</strong></p>
+<ul dir="auto">
+<li>The on-device model is now a <strong>downloadable list</strong> — choose from several Google Gemma tiers (1B through 27B) for local, private enhancement.</li>
+<li>New <strong>Coding</strong> and <strong>Chat</strong> prompts: Coding cleans dictated code and technical talk (without writing or answering), Chat keeps casual messages natural.</li>
+</ul>
+<h3 dir="auto">Install</h3>
+<ul dir="auto">
+<li><strong>New install:</strong> download <code class="notranslate">Zerm_2.4.0_aarch64.dmg</code> (Apple notarized, Apple Silicon).</li>
+<li><strong>Existing users:</strong> update in place via Zerm's built-in updater.</li>
+</ul>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.3.3">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.3.3">v2.3.3</a>
+            <time>15 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.3/Zerm_2.3.3_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.3.3</h2>
+            <div class="prose">
+<h2 dir="auto">Faster dictation start</h2>
+<p dir="auto">Pressing the dictation hotkey now shows live audio in about <strong>150 ms</strong>, down from <strong>~610 ms</strong> — roughly <strong>4x faster</strong>.</p>
+<p dir="auto">The recorder's waveform also animates as soon as the microphone is actually live. Previously it appeared instantly but sat flat and lifeless for over half a second, then jumped into sync, because the UI switched to "recording" before the audio hardware had started.</p>
+<h3 dir="auto">Details</h3>
+<p dir="auto">Two issues on the record-start path, both fixed:</p>
+<ul dir="auto">
+<li>The microphone permission check was scheduled behind the recorder window's first draw, costing ~311 ms on every trigger even when permission was already granted — and delaying audio startup behind it. This was a regression introduced in 2.2.0 alongside the (correct) addition of a real permission check.</li>
+<li>The waveform was mounted against a silent audio meter ~283 ms before any sound existed, rendering bars identical to the idle state until real audio arrived.</li>
+</ul>
+<p dir="auto">Measured over 115 real recording starts before the change, and re-measured after.</p>
+<h3 dir="auto">Install</h3>
+<ul dir="auto">
+<li><strong>Existing users:</strong> update in place via Zerm's built-in updater.</li>
+<li><strong>New install:</strong> download <code class="notranslate">Zerm_2.3.3_aarch64.dmg</code> below (Apple notarized, Apple Silicon).</li>
+</ul>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.3.2">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.3.2">v2.3.2</a>
+            <time>13 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.2/Zerm_2.3.2_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.3.2</h2>
+            <div class="prose">
+<h2 dir="auto">Fixes</h2>
+<ul dir="auto">
+<li><strong>Sticky “Update available” banner</strong> after install/check — only shows when the feed is strictly newer than the running build; clears on session end, abort, or relaunch.</li>
+<li><strong>Empty transcripts with a working mic</strong> (e.g. Yeti) — Whisper retries without VAD when the first pass is empty but the clip has energy; better empty-result messaging.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<p dir="auto">Open <code class="notranslate">Zerm_2.3.2_aarch64.dmg</code> or update from 2.3.1 via Check for Updates / sidebar banner.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.3.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.3.1">v2.3.1</a>
+            <time>13 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.1/Zerm_2.3.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.3.1</h2>
+            <div class="prose">
+<h2 dir="auto">Highlights</h2>
+<p dir="auto"><strong>Auto-update that actually surfaces in the UI.</strong></p>
+<ul dir="auto">
+<li>Sparkle background checks publish <code class="notranslate">updateAvailable</code> state</li>
+<li>Sidebar shows a bottom <strong>Update available</strong> card with <strong>Install update</strong></li>
+<li>Settings and menu bar show the same pending-update action</li>
+<li>Reliable find / not-found / error logging for field diagnosis</li>
+</ul>
+<h3 dir="auto">Upgrade path</h3>
+<ul dir="auto">
+<li><strong>From 2.3.0:</strong> Check for Updates (or wait for the background check) — you should see 2.3.1 offered and a sidebar banner.</li>
+<li><strong>From 2.2.x or earlier:</strong> Install this DMG once (EdDSA key was rotated in 2.3.0). Future updates work automatically.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<ol dir="auto">
+<li>Open <code class="notranslate">Zerm_2.3.1_aarch64.dmg</code> and drag <strong>Zerm</strong> to <strong>Applications</strong>.</li>
+<li>Apple Silicon only. Developer ID signed and notarized.</li>
+</ol>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.3.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.3.0">v2.3.0</a>
+            <time>13 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.0/Zerm_2.3.0_aarch64.dmg">Download .dmg <span>26.4 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.3.0</h2>
+            <div class="prose">
+<h2 dir="auto">Highlights</h2>
+<p dir="auto">Deep-review release: privacy, accuracy, stability, UX, and a working auto-update feed.</p>
+<h3 dir="auto">Privacy</h3>
+<ul dir="auto">
+<li>Transcripts are no longer written in cleartext to the macOS unified log (character counts only)</li>
+<li>Audio retention defaults <strong>on</strong> (14 days)</li>
+</ul>
+<h3 dir="auto">Accuracy</h3>
+<ul dir="auto">
+<li>Custom dictionary reaches local Whisper and Deepgram batch</li>
+<li>Continuous phase-carrying resampler + smarter multi-channel mix</li>
+<li>Language default <strong>auto</strong></li>
+<li>Safer hallucination filter (keeps legitimate parentheticals)</li>
+<li>Streaming failures fall back to full-file batch transcription</li>
+<li>Offline dictation commands: “new line”, “scratch that”, spoken punctuation</li>
+</ul>
+<h3 dir="auto">Stability &amp; UX</h3>
+<ul dir="auto">
+<li>System mute no longer sticks after a quick cancel during the start sound</li>
+<li>Session tokens prevent stale paste; busy-state watchdog</li>
+<li>Hard transcription failures show a real error notification (with deep links where useful)</li>
+<li>Model must be downloaded / API key present before recording starts</li>
+<li>Mic test in Settings; history workspace (edit, re-transcribe, local AI actions)</li>
+</ul>
+<h3 dir="auto">Ops</h3>
+<ul dir="auto">
+<li>First real unit tests</li>
+<li>MetricKit diagnostics</li>
+<li>Sparkle appcast signed for auto-updates (new installs of 2.3.0+)</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<ol dir="auto">
+<li>Open <code class="notranslate">Zerm_2.3.0_aarch64.dmg</code> and drag <strong>Zerm</strong> to <strong>Applications</strong>.</li>
+<li>First launch: approve the standard macOS prompts (microphone, accessibility).</li>
+</ol>
+<p dir="auto">Apple Silicon (arm64) only. Developer ID signed and notarized.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.2.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.2.0">v2.2.0</a>
+            <time>13 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.2.0/Zerm_2.2.0_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.2.0</h2>
+            <div class="prose">
+<h2 dir="auto">Highlights</h2>
+<ul dir="auto">
+<li><strong>First notarized release.</strong> The DMG is Developer ID signed and notarized by Apple — no more "Zerm is damaged" warnings and no <code class="notranslate">xattr</code> workaround needed. If a previous copy crashed at launch on download, this release fixes that too.</li>
+<li><strong>Microphone permission is now checked properly.</strong> If macOS has microphone access denied (or it was reset), Zerm now tells you and points to System Settings instead of silently recording nothing and reporting "Nothing transcribed".</li>
+<li><strong>Debug Logging mode.</strong> If recordings ever come back empty on your machine, enable <strong>Settings → Diagnostics → Debug Logging</strong>, reproduce once, and send us the log (<strong>Show in Finder</strong> reveals it). It records capture health — device, format, audio levels, driver errors — but never your words: transcripts are logged as character counts only, and no audio is kept.</li>
+</ul>
+<h2 dir="auto">Fixes</h2>
+<ul dir="auto">
+<li>Recording failures that previously vanished without a trace (audio-driver render errors, dropped devices, silent input) are now detected and reported in the debug log, with a per-recording summary that pinpoints the cause.</li>
+<li>Release pipeline: all embedded helper executables are now Developer ID signed with hardened runtime, fixing the launch crash some users hit with the 2.1.3 download.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<ol dir="auto">
+<li>Open <code class="notranslate">Zerm_2.2.0_aarch64.dmg</code> and drag <strong>Zerm</strong> to <strong>Applications</strong>.</li>
+<li>First launch: approve the standard macOS prompts (microphone, accessibility).</li>
+</ol>
+<p dir="auto">Apple Silicon (arm64) only.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.1.3">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.1.3">v2.1.3</a>
+            <time>2 July 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.3/Zerm_2.1.3_aarch64.dmg">Download .dmg <span>26.4 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.1.3</h2>
+            <div class="prose">
+<p dir="auto">Two chronic bugs fixed — hands-free dictation losing recordings, and Read Aloud misbehaving in terminals.</p>
+<h2 dir="auto">Fixed</h2>
+<h3 dir="auto">Hands-free dictation no longer loses recordings on auto-stop</h3>
+<p dir="auto">When the silence auto-stop ended a recording, the transcription and paste sometimes never happened — the capture simply vanished (or, on older versions, left a "Transcription Failed: Swift.CancellationError" history entry). Root cause: the auto-stop monitor triggered the stop from inside its own task, and the stop's first step cancelled that task — so the entire stop → transcribe → paste pipeline ran in an already-cancelled task and discarded the capture as if the user had cancelled. The monitor now triggers the stop from a fresh task. Manual hotkey stops were never affected.</p>
+<h3 dir="auto">Read Aloud now works reliably in terminals and TUI apps</h3>
+<p dir="auto">Two independent causes:</p>
+<ul dir="auto">
+<li>The simulated ⌘C used to grab the selection was posted while the Read Aloud hotkey's modifier keys were still physically held, so terminals received ⌃⌥⌘C instead of Copy — and the pasteboard was only polled for 100 ms, too short for embedded terminals and Electron panes. Zerm now waits for the hotkey to be released and retries with its own ⌘C (immune to held modifiers) with a longer pasteboard window, restoring your clipboard afterward.</li>
+<li>The on-device smart-reading model (Gemma) occasionally spoke a self-introduction ("…an advanced model by Google") instead of the selection. That happened when a terminal selection reduced to symbol-only junk (TUI borders), which provoked the model into chatting — and the phrasing slipped past the output validator. Symbol-only text is no longer sent to the model, and any output mentioning the model's identity is rejected in favor of the plainly-cleaned text.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<p dir="auto">Download <code class="notranslate">Zerm_2.1.3_aarch64.dmg</code>, drag Zerm to Applications, then clear the quarantine flag (build is not notarized yet):</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">xattr -dr com.apple.quarantine /Applications/Zerm.app</pre></div>
+<p dir="auto">Grant Accessibility and Screen Recording when prompted (Settings → Permissions).</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.1.2">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.1.2">v2.1.2</a>
+            <time>29 June 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.2/Zerm_2.1.2_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.1.2</h2>
+            <div class="prose">
+<h2 dir="auto">Fixes</h2>
+<ul dir="auto">
+<li><strong>Long recordings no longer drop mid-dictation.</strong> The silence auto-stop window was too short (1.1s), so a natural thinking pause could cut a long recording off. It's now 2.5s — forgiving of pauses, still prompt when you're done.</li>
+<li><strong>No more stuck "recording already running" after a drop.</strong> If the microphone is dropped mid-recording (unplugged, USB glitch, audio glitch), Zerm now detects the dropped capture within a few seconds, transcribes whatever was captured, tells you what happened, and returns to idle — so the next press starts a fresh recording immediately instead of being ignored.</li>
+<li><strong>Selecting text in terminals/TUIs now works.</strong> Reading or handling highlighted text in terminal apps and full-screen terminal UIs (e.g. Claude Code, cmux) reported "No text selected". Added a clipboard-based fallback (⌘C, auto-restored) that those apps handle reliably. This also restores Read-Aloud of selected text in those apps.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<ol dir="auto">
+<li>Open <code class="notranslate">Zerm_2.1.2_aarch64.dmg</code> and drag <strong>Zerm</strong> to <strong>Applications</strong>.</li>
+<li>Ad-hoc signed (not notarized). If macOS blocks first launch:
+<pre class="notranslate"><code class="notranslate">xattr -dr com.apple.quarantine /Applications/Zerm.app
+</code></pre>
+</li>
+</ol>
+<p dir="auto">Apple Silicon (arm64) only.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.1.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.1.1">v2.1.1</a>
+            <time>27 June 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.1/Zerm_2.1.1_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.1.1</h2>
+            <div class="prose">
+<h2 dir="auto">Fixes</h2>
+<ul dir="auto">
+<li><strong>Transcriptions no longer fail spuriously with "The operation couldn't be completed. (Swift.CancellationError error 1.)"</strong> — when a transcription was cancelled mid-flight (starting a new recording, toggling the hotkey again, engine teardown, or the safety timeout), the app mistakenly recorded it as a failure. Cancellation is now handled cleanly: the empty pending entry is discarded and no scary "Transcription Failed" record is written.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<ol dir="auto">
+<li>Open <code class="notranslate">Zerm_2.1.1_aarch64.dmg</code> and drag <strong>Zerm</strong> to <strong>Applications</strong>.</li>
+<li>This build is ad-hoc signed (not notarized). On first launch, if macOS blocks it:
+<pre class="notranslate"><code class="notranslate">xattr -dr com.apple.quarantine /Applications/Zerm.app
+</code></pre>
+then open it again.</li>
+</ol>
+<p dir="auto">Apple Silicon (arm64) only.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.1.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.1.0">v2.1.0</a>
+            <time>21 June 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.0/Zerm_2.1.0_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v2.1.0 — Smart Read Aloud + on-device AI</h2>
+            <div class="prose">
+<p dir="auto">Zerm v2.1.0 — Smart Read Aloud + Zerm's third on-device model.</p>
+<h2 dir="auto">Install (important)</h2>
+<p dir="auto">This build is <strong>signed ad-hoc (not yet notarized)</strong>, so macOS Gatekeeper warns on first launch. After opening the DMG and dragging <strong>Zerm</strong> to <strong>Applications</strong>:</p>
+<p dir="auto"><strong>Terminal (recommended):</strong></p>
+<pre class="notranslate"><code class="notranslate">xattr -dr com.apple.quarantine /Applications/Zerm.app
+open /Applications/Zerm.app
+</code></pre>
+<p dir="auto">Or right-click <strong>Zerm.app → Open → Open</strong>.</p>
+<p dir="auto">Then grant <strong>Accessibility</strong>, <strong>Screen Recording</strong>, and <strong>Microphone</strong> in System Settings → Privacy &amp; Security. Apple Silicon only.</p>
+<h2 dir="auto">What's new</h2>
+<p dir="auto"><strong>Three on-device models</strong> — Zerm now downloads and manages three local AI models: <strong>Whisper</strong> (speech-to-text), <strong>Kokoro</strong> (text-to-speech), and <strong>Gemma 4</strong> (the agentic LLM). Each runs fully offline; cloud providers remain optional.</p>
+<p dir="auto"><strong>Read Aloud</strong> — select text anywhere, press your shortcut, and Zerm reads it in a natural voice (local or cloud), using the same animated widget as dictation.</p>
+<p dir="auto"><strong>Smart Reading</strong> — text is cleaned instantly (acronyms, URLs, code, errors, emoji, tables) and can be rewritten by the on-device LLM so it sounds human, not robotic. The widget shows the real phase (Thinking… / Preparing… / speaking).</p>
+<p dir="auto"><strong>On-device AI Enhancement</strong> — dictation cleanup can run on the local Gemma model, no API key, recommended by default.</p>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li><strong>No auto-update</strong> in this build (requires a Sparkle signing key). Download new releases manually.</li>
+<li>A fully notarized, warning-free build is planned once Developer ID notarization is set up.</li>
+</ul>
+<p dir="auto">Full architecture docs: <a href="https://github.com/arcusis/Zerm/wiki" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/wiki</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.0.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.0.1">v2.0.1</a>
+            <time>18 June 2026</time>
+            
+            <span class="rel-dl rel-dl-none">No build attached</span>
+          </div>
+          <div class="rel-body">
+            <h2>v2.0.1 — Read Aloud fixes &amp; instant feel</h2>
+            <div class="prose">
+<p dir="auto">Patch release on top of v2.0.0, focused on Read Aloud.</p>
+<h3 dir="auto">🐛 Fixed</h3>
+<ul dir="auto">
+<li><strong>App froze when stopping Read Aloud.</strong> The audio-level metering tap removed itself from two threads at once (your stop + the playback-finished handler), which deadlocked AVAudioEngine and hung the whole app. The tap is now installed once and never removed in those paths.</li>
+</ul>
+<h3 dir="auto">⚡ Faster / instant feel</h3>
+<ul dir="auto">
+<li><strong>Instant widget:</strong> the recorder widget now appears the moment you trigger Read Aloud — before fetching the selected text or synthesizing — matching dictation's immediacy.</li>
+<li><strong>Chunked streaming:</strong> the first sentence plays as soon as it's synthesized while the rest synthesize in the background (no more waiting for the whole selection).</li>
+<li><strong>On-device pre-warm:</strong> the Kokoro model loads in the background when selected, so the first read is instant instead of a cold load.</li>
+</ul>
+<h3 dir="auto">Merged PRs</h3>
+<p dir="auto"><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4694734691" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/231" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/231/hovercard" href="https://github.com/arcusis/Zerm/pull/231">#231</a> (stop-hang fix + streaming), <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4694791721" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/232" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/232/hovercard" href="https://github.com/arcusis/Zerm/pull/232">#232</a> (instant widget + 2.0.1). Epic <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4690265752" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/220" data-hovercard-type="issue" data-hovercard-url="/arcusis/Zerm/issues/220/hovercard" href="https://github.com/arcusis/Zerm/issues/220">#220</a>.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.0.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.0.0">v2.0.0</a>
+            <time>18 June 2026</time>
+            
+            <span class="rel-dl rel-dl-none">No build attached</span>
+          </div>
+          <div class="rel-body">
+            <h2>v2.0.0 — Read Aloud (TTS)</h2>
+            <div class="prose">
+<h2 dir="auto">✨ Read Aloud (text-to-speech) — the mirror of dictation</h2>
+<p dir="auto">Select text anywhere, press your trigger, and Zerm reads it aloud. Configure in <strong>Settings → Read Aloud</strong>.</p>
+<h3 dir="auto">Voices</h3>
+<ul dir="auto">
+<li><strong>On-device: Kokoro 82M</strong> (sherpa-onnx) — download once (~330 MB), then fully offline, no API key.</li>
+<li><strong>Cloud:</strong> Deepgram Aura-2 (default) · Inworld TTS-1.5 Mini · ElevenLabs v3 · Gemini 3.1 Flash · OpenAI gpt-4o-mini-tts · Cartesia Sonic-3.5.</li>
+</ul>
+<h3 dir="auto">Trigger + widget</h3>
+<ul dir="auto">
+<li><strong>Modifier-key trigger dropdown</strong> (Right Command, Right Option, Fn, …) just like the dictation hotkey, plus a Custom key-combo option.</li>
+<li>Triggering Read Aloud shows the <strong>same animated mini/notch widget</strong> as dictation (a "Speaking" state), with <strong>double-Escape to cancel</strong>.</li>
+<li>Fully <strong>mutually exclusive</strong> with dictation — they can't run at once, no collisions.</li>
+</ul>
+<h3 dir="auto">Dashboard</h3>
+<ul dir="auto">
+<li>New <strong>Words Read Aloud</strong> stat alongside the dictation metrics.</li>
+</ul>
+<h3 dir="auto">Fixes included</h3>
+<ul dir="auto">
+<li>Voxtral streaming 400 (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4338176926" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/36" data-hovercard-type="issue" data-hovercard-url="/arcusis/Zerm/issues/36/hovercard" href="https://github.com/arcusis/Zerm/issues/36">#36</a>) and Whisper hallucination/temperature (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4338193884" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/150" data-hovercard-type="issue" data-hovercard-url="/arcusis/Zerm/issues/150/hovercard" href="https://github.com/arcusis/Zerm/issues/150">#150</a>).</li>
+<li>Fixed the recurring <strong>stuck/unfocusable window</strong> in menu-bar-only mode (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691293944" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/223" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/223/hovercard" href="https://github.com/arcusis/Zerm/pull/223">#223</a>).</li>
+</ul>
+<h3 dir="auto">Merged PRs</h3>
+<p dir="auto"><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4658875138" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/206" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/206/hovercard" href="https://github.com/arcusis/Zerm/pull/206">#206</a>, <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4690349541" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/221" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/221/hovercard" href="https://github.com/arcusis/Zerm/pull/221">#221</a>, <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691205577" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/222" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/222/hovercard" href="https://github.com/arcusis/Zerm/pull/222">#222</a>, <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691293944" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/223" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/223/hovercard" href="https://github.com/arcusis/Zerm/pull/223">#223</a>, <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691332275" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/224" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/224/hovercard" href="https://github.com/arcusis/Zerm/pull/224">#224</a>, <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691388369" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/225" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/225/hovercard" href="https://github.com/arcusis/Zerm/pull/225">#225</a>, <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691489326" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/226" data-hovercard-type="pull_request" data-hovercard-url="/arcusis/Zerm/pull/226/hovercard" href="https://github.com/arcusis/Zerm/pull/226">#226</a> · Epic <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4690265752" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/220" data-hovercard-type="issue" data-hovercard-url="/arcusis/Zerm/issues/220/hovercard" href="https://github.com/arcusis/Zerm/issues/220">#220</a>.</p>
+<hr>
+<p dir="auto"><strong>Status:</strong> Draft pending a notarized Developer ID build + Sparkle appcast entry (notary issuer ID / Sparkle EdDSA key required to publish the auto-updatable DMG). All source is on Production, tagged v2.0.0.</p>
+<p dir="auto"><strong>Coming next:</strong> local downloadable models for AI Enhancement (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4691490023" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/227" data-hovercard-type="issue" data-hovercard-url="/arcusis/Zerm/issues/227/hovercard" href="https://github.com/arcusis/Zerm/issues/227">#227</a>).</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v1.0.4">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v1.0.4">v1.0.4</a>
+            <time>13 June 2026</time>
+            
+            <span class="rel-dl rel-dl-none">No build attached</span>
+          </div>
+          <div class="rel-body">
+            <h2>v1.0.4</h2>
+            <div class="prose">
+<h2 dir="auto">Zerm v1.0.4</h2>
+<p dir="auto">Maintenance release syncing the relevant fix from upstream VoiceInk <strong>v1.79</strong> plus two transcription fixes.</p>
+<h3 dir="auto">Fixes</h3>
+<ul dir="auto">
+<li><strong>macOS 26 paste crash (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4509301874" data-permission-text="Title is private" data-url="https://github.com/arcusis/Zerm/issues/204" data-hovercard-type="issue" data-hovercard-url="/arcusis/Zerm/issues/204/hovercard" href="https://github.com/arcusis/Zerm/issues/204">#204</a>).</strong> The AppleScript paste path ran on a background queue, but the TIS input-source APIs assert they must run on the main queue on macOS 26, causing a SIGTRAP crash on paste. Now runs on the main actor (matches upstream VoiceInk v1.79's fix for #737).</li>
+<li><strong>Deepgram "Auto detect" language.</strong> Auto-detect sent no language parameter, so Deepgram silently defaulted to English. It now maps auto → <code class="notranslate">multi</code> for the multilingual Nova-3 model in both batch and streaming paths.</li>
+<li><strong>Idle transcription failure.</strong> The first FluidAudio inference after the app sat idle could fail with "Unable to compute asynchronous prediction" (stale CoreML handles after memory paging). Added a one-shot reload-from-disk and retry.</li>
+</ul>
+<h3 dir="auto">Notes</h3>
+<p dir="auto">Brings Zerm current with upstream VoiceInk stable v1.79.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v1.0.3">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v1.0.3">v1.0.3</a>
+            <time>22 May 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.3/Zerm_1.0.3_aarch64.dmg">Download .dmg <span>14.6 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v1.0.3</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard shows a setup banner.</li>
+<li>Zerm streams the hash-pinned Whisper model (~466 MB)<br>
+into your app-data dir automatically.</li>
+<li>Click <strong>Install Ollama</strong>. Zerm downloads the signed<br>
+installer from github.com/ollama/ollama/releases and<br>
+hands it to your OS's own signature check before it<br>
+runs.</li>
+<li>Gemma 3 4B is then pulled through your local Ollama.</li>
+<li>macOS: grant Accessibility and Microphone permission when prompted.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong> (macOS) / <strong>Ctrl+Shift+Space</strong> (Windows</p>
+<ul dir="auto">
+<li>Linux), speak, stop talking. Text lands in your clipboard.</li>
+</ul>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are signed with Developer ID. Stable releases wait for notarization + stapling; prereleases submit for notarization with <code class="notranslate">--skip-stapling</code> so Apple polling outages do not fail the release.</li>
+<li>macOS builds include the audio-input entitlement required for microphone capture.</li>
+<li>Windows installers are Authenticode signed when <code class="notranslate">WINDOWS_CERTIFICATE</code> is configured. Prereleases continue unsigned if that certificate is absent.</li>
+<li>Stable release jobs fail if required signing credentials are not configured.</li>
+<li>Linux .AppImage built on Ubuntu 22.04.</li>
+<li>SHA-256 checksums are attached as <code class="notranslate">SHA256SUMS.txt</code>.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v1.0.3" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v1.0.3</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v1.0.2">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v1.0.2">v1.0.2</a>
+            <time>22 May 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.2/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v1.0.2</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard shows a setup banner.</li>
+<li>Zerm streams the hash-pinned Whisper model (~466 MB)<br>
+into your app-data dir automatically.</li>
+<li>Click <strong>Install Ollama</strong>. Zerm downloads the signed<br>
+installer from github.com/ollama/ollama/releases and<br>
+hands it to your OS's own signature check before it<br>
+runs.</li>
+<li>Gemma 3 4B is then pulled through your local Ollama.</li>
+<li>macOS: grant Accessibility and Microphone permission when prompted.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong> (macOS) / <strong>Ctrl+Shift+Space</strong> (Windows</p>
+<ul dir="auto">
+<li>Linux), speak, stop talking. Text lands in your clipboard.</li>
+</ul>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are signed with Developer ID. Stable releases wait for notarization + stapling; prereleases submit for notarization with <code class="notranslate">--skip-stapling</code> so Apple polling outages do not fail the release.</li>
+<li>macOS builds include the audio-input entitlement required for microphone capture.</li>
+<li>Windows installers are Authenticode signed when <code class="notranslate">WINDOWS_CERTIFICATE</code> is configured. Prereleases continue unsigned if that certificate is absent.</li>
+<li>Stable release jobs fail if required signing credentials are not configured.</li>
+<li>Linux .AppImage built on Ubuntu 22.04.</li>
+<li>SHA-256 checksums are attached as <code class="notranslate">SHA256SUMS.txt</code>.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v1.0.2" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v1.0.2</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v1.0.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v1.0.1">v1.0.1</a>
+            <time>22 May 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.1/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v1.0.1</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard shows a setup banner.</li>
+<li>Zerm streams the hash-pinned Whisper model (~466 MB)<br>
+into your app-data dir automatically.</li>
+<li>Click <strong>Install Ollama</strong>. Zerm downloads the signed<br>
+installer from github.com/ollama/ollama/releases and<br>
+hands it to your OS's own signature check before it<br>
+runs.</li>
+<li>Gemma 3 4B is then pulled through your local Ollama.</li>
+<li>macOS: grant Accessibility and Microphone permission when prompted.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong> (macOS) / <strong>Ctrl+Shift+Space</strong> (Windows</p>
+<ul dir="auto">
+<li>Linux), speak, stop talking. Text lands in your clipboard.</li>
+</ul>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are signed with Developer ID. Stable releases wait for notarization + stapling; prereleases submit for notarization with <code class="notranslate">--skip-stapling</code> so Apple polling outages do not fail the release.</li>
+<li>macOS builds include the audio-input entitlement required for microphone capture.</li>
+<li>Windows installers are Authenticode signed when <code class="notranslate">WINDOWS_CERTIFICATE</code> is configured. Prereleases continue unsigned if that certificate is absent.</li>
+<li>Stable release jobs fail if required signing credentials are not configured.</li>
+<li>Linux .AppImage built on Ubuntu 22.04.</li>
+<li>SHA-256 checksums are attached as <code class="notranslate">SHA256SUMS.txt</code>.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v1.0.1" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v1.0.1</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v1.0.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v1.0.0">v1.0.0</a>
+            <time>27 April 2026</time>
+            
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.0/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v1.0.0</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard shows a setup banner.</li>
+<li>Zerm streams the hash-pinned Whisper model (~466 MB)<br>
+into your app-data dir automatically.</li>
+<li>Click <strong>Install Ollama</strong>. Zerm downloads the signed<br>
+installer from github.com/ollama/ollama/releases and<br>
+hands it to your OS's own signature check before it<br>
+runs.</li>
+<li>Gemma 3 4B is then pulled through your local Ollama.</li>
+<li>macOS: grant Accessibility and Microphone permission when prompted.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong> (macOS) / <strong>Ctrl+Shift+Space</strong> (Windows</p>
+<ul dir="auto">
+<li>Linux), speak, stop talking. Text lands in your clipboard.</li>
+</ul>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are signed with Developer ID. Stable releases wait for notarization + stapling; prereleases submit for notarization with <code class="notranslate">--skip-stapling</code> so Apple polling outages do not fail the release.</li>
+<li>macOS builds include the audio-input entitlement required for microphone capture.</li>
+<li>Windows installers are Authenticode signed when <code class="notranslate">WINDOWS_CERTIFICATE</code> is configured. Prereleases continue unsigned if that certificate is absent.</li>
+<li>Stable release jobs fail if required signing credentials are not configured.</li>
+<li>Linux .AppImage built on Ubuntu 22.04.</li>
+<li>SHA-256 checksums are attached as <code class="notranslate">SHA256SUMS.txt</code>.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v1.0.0" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v1.0.0</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v0.1.0-alpha.18">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v0.1.0-alpha.18">v0.1.0-alpha.18</a>
+            <time>27 April 2026</time>
+            <span class="rel-badge pre">Pre-release</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v0.1.0-alpha.18/Zerm_0.1.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v0.1.0-alpha.18</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard shows a setup banner.</li>
+<li>Zerm streams the hash-pinned Whisper model (~466 MB)<br>
+into your app-data dir automatically.</li>
+<li>Click <strong>Install Ollama</strong>. Zerm downloads the signed<br>
+installer from github.com/ollama/ollama/releases and<br>
+hands it to your OS's own signature check before it<br>
+runs.</li>
+<li>Gemma 3 4B is then pulled through your local Ollama.</li>
+<li>macOS: grant Accessibility and Microphone permission when prompted.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong> (macOS) / <strong>Ctrl+Shift+Space</strong> (Windows</p>
+<ul dir="auto">
+<li>Linux), speak, stop talking. Text lands in your clipboard.</li>
+</ul>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are signed with Developer ID. Stable releases wait for notarization + stapling; prereleases submit for notarization with <code class="notranslate">--skip-stapling</code> so Apple polling outages do not fail the release.</li>
+<li>macOS builds include the audio-input entitlement required for microphone capture.</li>
+<li>Windows installers are Authenticode signed when <code class="notranslate">WINDOWS_CERTIFICATE</code> is configured. Prereleases continue unsigned if that certificate is absent.</li>
+<li>Stable release jobs fail if required signing credentials are not configured.</li>
+<li>Linux .AppImage built on Ubuntu 22.04.</li>
+<li>SHA-256 checksums are attached as <code class="notranslate">SHA256SUMS.txt</code>.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.18" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.18</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v0.1.0-alpha.5">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v0.1.0-alpha.5">v0.1.0-alpha.5</a>
+            <time>21 April 2026</time>
+            <span class="rel-badge pre">Pre-release</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v0.1.0-alpha.5/Zerm_0.1.0_aarch64.dmg">Download .dmg <span>4.1 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v0.1.0-alpha.5</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard appears with a "Set up Zerm" banner.</li>
+<li>Click <strong>Download Whisper model</strong> in the banner — Zerm streams<br>
+the multilingual ggml-small.bin (~466 MB) into your app data<br>
+directory and loads it automatically.</li>
+<li>Install <a href="https://ollama.com/download" rel="noopener noreferrer" target="_blank" rel="nofollow">Ollama</a>, then in a<br>
+terminal: <code class="notranslate">ollama pull gemma3:4b</code>. Zerm picks it up live.</li>
+<li>macOS: grant Accessibility permission when prompted so the<br>
+Right Option hotkey can fire and auto-paste can simulate ⌘V.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong>, speak, stop talking. The cleaned text<br>
+lands in your clipboard and pastes into whatever app is focused.</p>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are unsigned for this prerelease — first launch<br>
+requires <code class="notranslate">xattr -cr /Applications/Zerm.app</code> or right-click → Open.</li>
+<li>Windows .msi is unsigned; SmartScreen will warn — click "More<br>
+info" → "Run anyway".</li>
+<li>Linux .AppImage is built on Ubuntu 22.04 — should run on<br>
+22.04+.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.5" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.5</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v0.1.0-alpha.4">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v0.1.0-alpha.4">v0.1.0-alpha.4</a>
+            <time>21 April 2026</time>
+            <span class="rel-badge pre">Pre-release</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v0.1.0-alpha.4/Zerm_0.1.0_aarch64.dmg">Download .dmg <span>4.1 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v0.1.0-alpha.4</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard appears with a "Set up Zerm" banner.</li>
+<li>Click <strong>Download Whisper model</strong> in the banner — Zerm streams<br>
+the multilingual ggml-small.bin (~466 MB) into your app data<br>
+directory and loads it automatically.</li>
+<li>Install <a href="https://ollama.com/download" rel="noopener noreferrer" target="_blank" rel="nofollow">Ollama</a>, then in a<br>
+terminal: <code class="notranslate">ollama pull gemma3:4b</code>. Zerm picks it up live.</li>
+<li>macOS: grant Accessibility permission when prompted so the<br>
+Right Option hotkey can fire and auto-paste can simulate ⌘V.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong>, speak, stop talking. The cleaned text<br>
+lands in your clipboard and pastes into whatever app is focused.</p>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are unsigned for this prerelease — first launch<br>
+requires <code class="notranslate">xattr -cr /Applications/Zerm.app</code> or right-click → Open.</li>
+<li>Windows .msi is unsigned; SmartScreen will warn — click "More<br>
+info" → "Run anyway".</li>
+<li>Linux .AppImage is built on Ubuntu 22.04 — should run on<br>
+22.04+.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.4" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.4</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v0.1.0-alpha.3">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v0.1.0-alpha.3">v0.1.0-alpha.3</a>
+            <time>21 April 2026</time>
+            <span class="rel-badge pre">Pre-release</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v0.1.0-alpha.3/Zerm_0.1.0_aarch64.dmg">Download .dmg <span>4.1 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v0.1.0-alpha.3</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard appears with a "Set up Zerm" banner.</li>
+<li>Click <strong>Download Whisper model</strong> in the banner — Zerm streams<br>
+the multilingual ggml-small.bin (~466 MB) into your app data<br>
+directory and loads it automatically.</li>
+<li>Install <a href="https://ollama.com/download" rel="noopener noreferrer" target="_blank" rel="nofollow">Ollama</a>, then in a<br>
+terminal: <code class="notranslate">ollama pull gemma3:4b</code>. Zerm picks it up live.</li>
+<li>macOS: grant Accessibility permission when prompted so the<br>
+Right Option hotkey can fire and auto-paste can simulate ⌘V.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong>, speak, stop talking. The cleaned text<br>
+lands in your clipboard and pastes into whatever app is focused.</p>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are unsigned for this prerelease — first launch<br>
+requires <code class="notranslate">xattr -cr /Applications/Zerm.app</code> or right-click → Open.</li>
+<li>Windows .msi is unsigned; SmartScreen will warn — click "More<br>
+info" → "Run anyway".</li>
+<li>Linux .AppImage is built on Ubuntu 22.04 — should run on<br>
+22.04+.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.3" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.3</a></p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v0.1.0-alpha.2">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v0.1.0-alpha.2">v0.1.0-alpha.2</a>
+            <time>20 April 2026</time>
+            <span class="rel-badge pre">Pre-release</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v0.1.0-alpha.2/Zerm_0.1.0_aarch64.dmg">Download .dmg <span>4.0 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v0.1.0-alpha.2</h2>
+            <div class="prose">
+<h2 dir="auto">First launch</h2>
+<ol dir="auto">
+<li>Open Zerm. The dashboard appears with a "Set up Zerm" banner.</li>
+<li>Click <strong>Download Whisper model</strong> in the banner — Zerm streams<br>
+the multilingual ggml-small.bin (~466 MB) into your app data<br>
+directory and loads it automatically.</li>
+<li>Install <a href="https://ollama.com/download" rel="noopener noreferrer" target="_blank" rel="nofollow">Ollama</a>, then in a<br>
+terminal: <code class="notranslate">ollama pull gemma3:4b</code>. Zerm picks it up live.</li>
+<li>macOS: grant Accessibility permission when prompted so the<br>
+Right Option hotkey can fire and auto-paste can simulate ⌘V.</li>
+</ol>
+<h2 dir="auto">Use it</h2>
+<p dir="auto">Tap <strong>Right Option</strong>, speak, stop talking. The cleaned text<br>
+lands in your clipboard and pastes into whatever app is focused.</p>
+<h2 dir="auto">Notes</h2>
+<ul dir="auto">
+<li>macOS builds are unsigned for this prerelease — first launch<br>
+requires <code class="notranslate">xattr -cr /Applications/Zerm.app</code> or right-click → Open.</li>
+<li>Windows .msi is unsigned; SmartScreen will warn — click "More<br>
+info" → "Run anyway".</li>
+<li>Linux .AppImage is built on Ubuntu 22.04 — should run on<br>
+22.04+.</li>
+</ul>
+<h2 dir="auto">Changes</h2>
+<p dir="auto"><a href="https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.2" rel="noopener noreferrer" target="_blank">https://github.com/arcusis/Zerm/commits/v0.1.0-alpha.2</a></p>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
         >Zerm <span id="release-tag">latest</span> — dictation and read aloud,
         running on-device.</span
       >
-      <a href="https://github.com/arcusis/Zerm/releases">Release notes</a>
+      <a href="./changelog.html">Release notes</a>
     </div>
 
     <header class="topbar">
@@ -43,7 +43,7 @@
           <a href="#dictation">Dictation</a>
           <a href="#read-aloud">Read aloud</a>
           <a href="#privacy">Privacy</a>
-          <a href="#origin">Origin</a>
+          <a href="./changelog.html">Changelog</a>
         </nav>
         <div class="topbar-actions">
           <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
@@ -211,7 +211,7 @@
             </li>
           </ol>
 
-          <a class="text-link" href="https://github.com/arcusis/Zerm/blob/Production/docs/native-writing-layer-verification.md"
+          <a class="text-link" href="./verification.html"
             >Native writing layer verification</a
           >
         </div>
@@ -370,7 +370,7 @@
             <strong>.zip</strong>
             <small>Unzip into /Applications</small>
           </a>
-          <a class="card download-card reveal" href="https://github.com/arcusis/Zerm/blob/Production/BUILDING.md">
+          <a class="card download-card reveal" href="./building.html">
             <span class="dl-kind">Source</span>
             <strong>xcodebuild</strong>
             <small>Xcode 16 · Swift &amp; SwiftUI</small>
@@ -397,12 +397,12 @@
             <strong>Beingpax/VoiceInk</strong>
             <small>The original GPLv3 project</small>
           </a>
-          <a class="card origin-card reveal" href="https://github.com/arcusis/Zerm/blob/Production/NOTICE">
+          <a class="card origin-card reveal" href="./notice.html">
             <span class="dl-kind">Attribution</span>
             <strong>NOTICE</strong>
             <small>Migration and modification notes</small>
           </a>
-          <a class="card origin-card reveal" href="https://github.com/arcusis/Zerm/blob/Production/LICENSE">
+          <a class="card origin-card reveal" href="./license.html">
             <span class="dl-kind">License</span>
             <strong>GNU GPLv3</strong>
             <small>Source license for Zerm</small>
@@ -437,10 +437,11 @@
         </div>
         <nav class="foot-links" aria-label="Footer">
           <a href="#download">Download</a>
-          <a href="https://github.com/arcusis/Zerm">Repository</a>
-          <a href="https://github.com/arcusis/Zerm/issues">Issues</a>
-          <a href="https://github.com/arcusis/Zerm/wiki">Wiki</a>
-          <a href="https://github.com/Beingpax/VoiceInk">VoiceInk</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
         </nav>
         <p class="foot-legal">
           © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax

--- a/docs/license.html
+++ b/docs/license.html
@@ -1,0 +1,747 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>License — Zerm</title>
+    <meta name="description" content="Zerm is free software. The full license text follows." />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="License — Zerm" />
+    <meta property="og:description" content="Zerm is free software. The full license text follows." />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="./#models">Models</a>
+          <a href="./#dictation">Dictation</a>
+          <a href="./#read-aloud">Read aloud</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./changelog.html">Changelog</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="page">
+      <section class="page-hero">
+        <p class="eyebrow">License</p>
+        <h1>GNU General Public License v3</h1>
+        <p class="lede">Zerm is free software. The full license text follows.</p>
+      </section>
+      <section class="doc"><div class="prose">
+<pre class="plain">                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. &lt;https://fsf.org/&gt;
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    &lt;one line to give the program's name and a brief idea of what it does.&gt;
+    Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    &lt;program&gt;  Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+&lt;https://www.gnu.org/licenses/&gt;.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+&lt;https://www.gnu.org/licenses/why-not-lgpl.html&gt;.
+</pre>
+      </div></section>
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>

--- a/docs/notice.html
+++ b/docs/notice.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Attribution — Zerm</title>
+    <meta name="description" content="Zerm is a modified GPLv3 derivative of VoiceInk by Beingpax. This is the NOTICE file, verbatim." />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="Attribution — Zerm" />
+    <meta property="og:description" content="Zerm is a modified GPLv3 derivative of VoiceInk by Beingpax. This is the NOTICE file, verbatim." />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="./#models">Models</a>
+          <a href="./#dictation">Dictation</a>
+          <a href="./#read-aloud">Read aloud</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./changelog.html">Changelog</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="page">
+      <section class="page-hero">
+        <p class="eyebrow">Origin</p>
+        <h1>Attribution</h1>
+        <p class="lede">Zerm is a modified GPLv3 derivative of VoiceInk by Beingpax. This is the NOTICE file, verbatim.</p>
+      </section>
+      <section class="doc"><div class="prose">
+<pre class="plain">Zerm is a modified GPLv3 derivative based on VoiceInk.
+
+Original upstream project:
+https://github.com/Beingpax/VoiceInk
+
+Original author / upstream maintainer:
+Beingpax / Pax
+
+Imported upstream commit recorded during migration:
+620a8439319fd849f0905b901ad3567382a0c5ab
+
+Zerm-specific changes include application branding, bundle identifiers, local
+build output names, project paths, product copy, permission wording, release
+metadata, and ongoing feature and reliability work.
+
+The VoiceInk-derived application code remains licensed under the GNU General
+Public License v3.0 as described in LICENSE. Zerm keeps this license and keeps
+public attribution to the upstream project.
+</pre>
+      </div></section>
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Privacy — Zerm</title>
+    <meta
+      name="description"
+      content="What Zerm records, what stays on your Mac, what leaves it and only when you ask, and which macOS permissions are needed for what."
+    />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="Privacy — Zerm" />
+    <meta
+      property="og:description"
+      content="Zerm is a voice app with microphone and Accessibility access. That deserves specifics rather than a slogan."
+    />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="./#models">Models</a>
+          <a href="./#dictation">Dictation</a>
+          <a href="./#read-aloud">Read aloud</a>
+          <a href="./privacy.html" aria-current="page">Privacy</a>
+          <a href="./changelog.html">Changelog</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="page">
+      <section class="page-hero">
+        <p class="eyebrow">Privacy model</p>
+        <h1>What leaves your Mac, and when.</h1>
+        <p class="lede">
+          Zerm listens to your microphone and can type into any application. Two
+          capabilities worth being specific about. This page says exactly what
+          happens to your audio, your text, and your permissions — and none of it
+          requires taking our word for it, because the source is public.
+        </p>
+      </section>
+
+      <section class="doc">
+        <div class="prose">
+          <h2>The short version</h2>
+          <p>
+            On the default configuration, nothing leaves your Mac. Speech-to-text,
+            text-to-speech, and the enhancement model all run locally. There is no
+            account, no telemetry service, and no server belonging to us in the
+            path. Cloud providers exist as an option, and they stay dormant until
+            you add a key and select one.
+          </p>
+
+          <h2>Audio</h2>
+          <ul>
+            <li>
+              Recording happens through the standard macOS microphone APIs, which
+              means the orange recording indicator in the menu bar applies to Zerm
+              exactly as it does to any other app.
+            </li>
+            <li>
+              On the local transcription path — Whisper, FluidAudio, or Apple
+              Speech — the audio is processed on the machine and is never
+              transmitted.
+            </li>
+            <li>
+              If you select a cloud transcription provider, the audio for that
+              request is sent to that provider under your own API key, subject to
+              their terms. This only happens for providers you configure yourself.
+            </li>
+            <li>
+              Recordings are kept locally alongside their transcripts in History,
+              and can be deleted individually or wholesale.
+            </li>
+          </ul>
+
+          <h2>Text</h2>
+          <ul>
+            <li>
+              Transcripts are stored locally in History so you can search, copy, or
+              retry them. Deleting an entry deletes it.
+            </li>
+            <li>
+              AI enhancement runs on the on-device model by default. Choosing a
+              cloud provider sends the transcript to that provider instead.
+            </li>
+            <li>
+              Storage of AI request payloads is a separate setting from making the
+              requests at all. Turning on enhancement does not silently start
+              logging what you dictated.
+            </li>
+            <li>
+              Read Aloud reads the current selection. Smart Reading cleans that text
+              before it is spoken — on-device unless you have picked a cloud voice.
+            </li>
+          </ul>
+
+          <h2>Permissions, and what each one buys</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Permission</th>
+                <th>Needed for</th>
+                <th>If you decline</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Microphone</td>
+                <td>Recording anything at all</td>
+                <td>Dictation cannot work</td>
+              </tr>
+              <tr>
+                <td>Accessibility</td>
+                <td>Pasting at your cursor, reading the current selection</td>
+                <td>Zerm falls back to the clipboard</td>
+              </tr>
+              <tr>
+                <td>Screen Recording</td>
+                <td>Power Mode reading the active window or browser URL</td>
+                <td>Power Mode context features stay off; everything else works</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Each is requested in context, at the point the feature needs it, rather
+            than in a wall of prompts at first launch. Setup failures are surfaced
+            instead of being swallowed.
+          </p>
+
+          <h2>Power Mode context</h2>
+          <p>
+            Power Mode adapts the prompt to where you are writing, which means it
+            reads the frontmost application and, for browsers, the current URL.
+            That context is used to select a prompt for workflows you have
+            configured. It is not accumulated into a history or a profile.
+          </p>
+
+          <h2>Network</h2>
+          <p>
+            Zerm reaches the network for three things: downloading the models on
+            first use, checking for application updates, and any cloud provider you
+            have explicitly configured. With models already downloaded and no cloud
+            provider selected, the dictation and read-aloud loop works with the
+            network off entirely.
+          </p>
+
+          <h2>Verifying any of this</h2>
+          <p>
+            Zerm is GPLv3. The source for every claim on this page is public, and
+            the parts that matter most — the recorder, the transcription pipeline,
+            the paste path, and the provider clients — are readable without
+            building anything.
+          </p>
+          <p>
+            <a href="https://github.com/arcusis/Zerm" rel="noopener noreferrer" target="_blank">Read the source</a>
+            · <a href="./license.html">License</a>
+            · <a href="./notice.html">Attribution</a>
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1026,6 +1026,302 @@ kbd {
   font-size: 12.5px;
 }
 
+/* ---------- Subpages ---------- */
+
+.page {
+  padding-bottom: clamp(56px, 8vw, 96px);
+}
+
+.page-hero {
+  padding: clamp(52px, 7vw, 88px) 0 clamp(32px, 4vw, 52px);
+  border-bottom: 1px solid var(--line-soft);
+  margin-bottom: clamp(36px, 5vw, 60px);
+}
+
+.page-hero h1 {
+  font-size: clamp(34px, 5vw, 54px);
+}
+
+.page-hero .lede {
+  margin-top: 16px;
+}
+
+.topbar-nav a[aria-current="page"] {
+  color: var(--text);
+}
+
+/* ---------- Rendered markdown ---------- */
+
+.prose {
+  color: var(--text-2);
+  font-size: 15.5px;
+  line-height: 1.65;
+}
+
+.prose > :first-child {
+  margin-top: 0;
+}
+
+.prose > :last-child {
+  margin-bottom: 0;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+  margin: 30px 0 12px;
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  line-height: 1.2;
+}
+
+.prose h1 { font-size: 24px; }
+.prose h2 { font-size: 20px; }
+.prose h3 { font-size: 17px; }
+.prose h4 { font-size: 15px; }
+
+.prose p {
+  margin: 0 0 14px;
+}
+
+.prose strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.prose a {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--text-3);
+  transition: text-decoration-color 0.2s var(--ease);
+}
+
+.prose a:hover {
+  text-decoration-color: var(--text);
+}
+
+.prose ul,
+.prose ol {
+  margin: 0 0 16px;
+  padding-left: 22px;
+}
+
+.prose li {
+  margin-bottom: 7px;
+}
+
+.prose li::marker {
+  color: var(--text-3);
+}
+
+.prose code {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: var(--s3);
+  font-size: 0.87em;
+}
+
+.prose pre {
+  margin: 0 0 16px;
+  padding: 16px 18px;
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  background: var(--s2);
+  overflow-x: auto;
+}
+
+.prose pre code {
+  padding: 0;
+  background: none;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.prose table {
+  width: 100%;
+  margin: 0 0 16px;
+  border-collapse: collapse;
+  font-size: 14px;
+  display: block;
+  overflow-x: auto;
+}
+
+.prose th,
+.prose td {
+  padding: 9px 14px;
+  border: 1px solid var(--line);
+  text-align: left;
+}
+
+.prose th {
+  background: var(--s2);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.prose blockquote {
+  margin: 0 0 16px;
+  padding: 2px 0 2px 16px;
+  border-left: 2px solid var(--s4);
+  color: var(--text-3);
+}
+
+.prose hr {
+  margin: 26px 0;
+  border: 0;
+  border-top: 1px solid var(--line-soft);
+}
+
+.prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.prose .plain,
+pre.plain {
+  margin: 0;
+  padding: 22px;
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  background: var(--s1);
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.doc {
+  max-width: 760px;
+}
+
+/* ---------- Changelog ---------- */
+
+.rel-list {
+  display: grid;
+  gap: 0;
+}
+
+.rel {
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
+  gap: clamp(24px, 4vw, 56px);
+  padding: 40px 0;
+  border-top: 1px solid var(--line-soft);
+  scroll-margin-top: 84px;
+}
+
+.rel:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.rel-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  position: sticky;
+  top: 84px;
+  align-self: start;
+}
+
+.rel-tag {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.rel-tag:hover {
+  color: var(--rec-text);
+}
+
+.rel-meta time {
+  color: var(--text-3);
+  font-size: 13px;
+}
+
+.rel-badge {
+  padding: 3px 9px;
+  border-radius: 200px;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.rel-badge.now {
+  background: rgba(255, 59, 48, 0.12);
+  color: var(--rec-text);
+}
+
+.rel-badge.pre {
+  background: var(--s3);
+  color: var(--text-2);
+}
+
+.rel-dl {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  margin-top: 4px;
+  padding: 7px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--s1);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 550;
+  transition: background-color 0.25s var(--ease), border-color 0.25s var(--ease);
+}
+
+.rel-dl:hover {
+  background: var(--s2);
+  border-color: var(--s4);
+}
+
+.rel-dl span {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.rel-dl-none {
+  border-style: dashed;
+  background: none;
+  color: var(--text-3);
+  font-weight: 400;
+}
+
+.rel-dl-none:hover {
+  background: none;
+  border-color: var(--line);
+}
+
+.rel-body > h2 {
+  margin: 0 0 16px;
+  font-size: clamp(22px, 2.6vw, 28px);
+  letter-spacing: -0.026em;
+}
+
+@media (max-width: 820px) {
+  .rel {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .rel-meta {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+}
+
 /* ---------- Reveal ---------- */
 
 .reveal {

--- a/docs/verification.html
+++ b/docs/verification.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Native writing layer verification — Zerm</title>
+    <meta name="description" content="How the macOS insertion, permission, and paste behaviours are verified." />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="Native writing layer verification — Zerm" />
+    <meta property="og:description" content="How the macOS insertion, permission, and paste behaviours are verified." />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          <a href="./#models">Models</a>
+          <a href="./#dictation">Dictation</a>
+          <a href="./#read-aloud">Read aloud</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./changelog.html">Changelog</a>
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/arcusis/Zerm">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="page">
+      <section class="page-hero">
+        <p class="eyebrow">Engineering</p>
+        <h1>Native writing layer verification</h1>
+        <p class="lede">How the macOS insertion, permission, and paste behaviours are verified.</p>
+      </section>
+      <section class="doc"><div class="prose">
+<h1 dir="auto">Native Writing-Layer Verification</h1>
+<p dir="auto">This checklist covers the native OS behaviors that make Zerm feel like a writing<br>
+layer instead of only a transcription app. It is meant for release candidates,<br>
+local app replacements, and regressions involving the floating pill,<br>
+Accessibility, or auto-paste.</p>
+<p dir="auto">Run the read-only diagnostics script first:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">scripts/verify-native-writing-layer.sh</pre></div>
+<p dir="auto">For release artifacts, make signing problems fail the run:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">scripts/verify-native-writing-layer.sh --app /Applications/Zerm.app --strict-release</pre></div>
+<p dir="auto">The script is non-destructive by default. The auto-paste self-test can insert<br>
+text into the focused application and is only enabled when both an explicit flag<br>
+and an acknowledgement environment variable are present:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">ZERM_VERIFY_ALLOW_INPUT=1 scripts/verify-native-writing-layer.sh --run-autopaste-self-test</pre></div>
+<h2 dir="auto">macOS Signing And Accessibility</h2>
+<p dir="auto">Accessibility trust must be evaluated against the currently running binary, not<br>
+only the visible row in System Settings. A replaced or ad-hoc signed local build<br>
+can leave System Settings showing <code class="notranslate">Zerm.app</code> enabled while<br>
+<code class="notranslate">AXIsProcessTrusted()</code> returns false for the new process.</p>
+<p dir="auto">Release builds must satisfy all of these checks:</p>
+<ul dir="auto">
+<li>Bundle path is the expected installed bundle, usually <code class="notranslate">/Applications/Zerm.app</code>.</li>
+<li><code class="notranslate">CFBundleIdentifier</code> is <code class="notranslate">com.arcusis.zerm</code>.</li>
+<li><code class="notranslate">codesign --verify --deep --strict</code> succeeds.</li>
+<li><code class="notranslate">codesign -dv --verbose=4</code> reports <code class="notranslate">Identifier=com.arcusis.zerm</code>.</li>
+<li><code class="notranslate">TeamIdentifier</code> is present.</li>
+<li><code class="notranslate">Authority=Developer ID Application: ...</code> is present for public macOS builds.</li>
+<li><code class="notranslate">spctl -a -vv --type exec</code> accepts the app.</li>
+<li>The dashboard permission diagnostics report Accessibility as trusted after the<br>
+app is opened from the installed bundle.</li>
+</ul>
+<p dir="auto">If a local build is ad-hoc signed, expect TCC instability. Remove and re-add the<br>
+exact installed <code class="notranslate">Zerm.app</code> in System Settings -&gt; Privacy &amp; Security -&gt;<br>
+Accessibility after the build is installed. Do not use this local result to<br>
+judge release-signing behavior.</p>
+<p dir="auto">Automation is separate from Accessibility. It is only required for the System<br>
+Events fallback path. Direct Accessibility insertion and CoreGraphics event<br>
+posting can work without Automation, so diagnostics should report them<br>
+separately.</p>
+<h2 dir="auto">Auto-Paste Self-Test</h2>
+<p dir="auto">Use a disposable target such as a scratch TextEdit document.</p>
+<ol dir="auto">
+<li>
+<p dir="auto">Install the exact app bundle being tested.</p>
+</li>
+<li>
+<p dir="auto">Open the app once from the installed bundle.</p>
+</li>
+<li>
+<p dir="auto">Confirm Zerm is enabled in Accessibility for that exact bundle.</p>
+</li>
+<li>
+<p dir="auto">Focus a scratch text field.</p>
+</li>
+<li>
+<p dir="auto">Run:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">ZERM_VERIFY_ALLOW_INPUT=1 scripts/verify-native-writing-layer.sh --run-autopaste-self-test</pre></div>
+</li>
+<li>
+<p dir="auto">Confirm the generated <code class="notranslate">ZERM_AUTOPASTE_SELF_TEST_*</code> token appears exactly<br>
+once in the target field.</p>
+</li>
+<li>
+<p dir="auto">If the command succeeds but text does not appear, capture:</p>
+<ul dir="auto">
+<li>target app name and bundle id,</li>
+<li>whether the target is native, browser, Electron, terminal, or secure field,</li>
+<li>dashboard insertion diagnostics,</li>
+<li>Accessibility and Automation status,</li>
+<li>whether Zerm was signed, ad-hoc signed, or rejected by Gatekeeper.</li>
+</ul>
+</li>
+</ol>
+<p dir="auto">The self-test only proves that Zerm can post its current paste path. It does not<br>
+replace target-specific testing in real apps.</p>
+<h2 dir="auto">Full-Screen Pill Manual Test</h2>
+<p dir="auto">The pill must be treated as native overlay behavior. Test across full-screen<br>
+Spaces and multiple displays.</p>
+<ol dir="auto">
+<li>Open TextEdit, Arc or Chrome, Slack or Discord, and a terminal/editor.</li>
+<li>Put one target app into macOS full-screen mode.</li>
+<li>Move the pointer to that full-screen display.</li>
+<li>Press the Zerm hotkey.</li>
+<li>Expected result: the floating pill appears immediately above the full-screen<br>
+app on the active display.</li>
+<li>Speak for two or three seconds.</li>
+<li>Expected result: the pill stays visible while recording, shows processing,<br>
+then shows copied, pasted, or failure state.</li>
+<li>Switch Spaces and repeat.</li>
+<li>Move to a second display and repeat.</li>
+</ol>
+<p dir="auto">Capture failures with these fields:</p>
+<ul dir="auto">
+<li>target app and bundle id,</li>
+<li>number of displays,</li>
+<li>whether the target is full-screen, tiled, or normal windowed,</li>
+<li>whether the pill did not show, showed behind the app, or appeared on another<br>
+display,</li>
+<li>whether the hotkey still started recording,</li>
+<li>screenshot or screen recording if available.</li>
+</ul>
+<h2 dir="auto">Cross-Platform Paste Support Matrix</h2>
+<markdown-accessiblity-table><table role="table">
+<thead>
+<tr>
+<th>Platform</th>
+<th>Current expectation</th>
+<th>Required permissions and caveats</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>macOS</td>
+<td>Auto-paste is supported and under active hardening.</td>
+<td>Accessibility is required. Automation is only required for the System Events fallback. Release builds must be Developer ID signed for stable TCC trust.</td>
+</tr>
+<tr>
+<td>Windows</td>
+<td>Clipboard copy is supported; native auto-paste should stay gated until the helper path is implemented.</td>
+<td>Requires SendInput integration, modifier masking, clipboard sequence tracking, timeouts, helper crash handling, and diagnostics before production auto-paste is claimed.</td>
+</tr>
+<tr>
+<td>Linux X11</td>
+<td>Clipboard copy is supported; native auto-paste should stay gated until the X11 strategy is implemented.</td>
+<td>Requires X11 clipboard plus key synthesis support and dependency checks such as <code class="notranslate">libxdo</code>.</td>
+</tr>
+<tr>
+<td>Linux Wayland</td>
+<td>Copy-only or explicit unsupported state.</td>
+<td>Wayland paste support is compositor and portal dependent. Do not present it as a generic Linux capability.</td>
+</tr>
+</tbody>
+</table></markdown-accessiblity-table>
+<h2 dir="auto">Release-Candidate Checklist</h2>
+<ul dir="auto">
+<li>Run the normal CI verification commands from the README.</li>
+<li>Run <code class="notranslate">scripts/verify-native-writing-layer.sh --strict-release</code> against the<br>
+installed macOS artifact.</li>
+<li>Confirm the dashboard permission diagnostics agree with macOS Accessibility<br>
+after toggling the permission.</li>
+<li>Run the interactive auto-paste self-test in a scratch field.</li>
+<li>Run the target matrix for TextEdit, browser, Electron, terminal/editor, and<br>
+secure field refusal.</li>
+<li>Run the full-screen pill test on at least one full-screen app and one<br>
+multi-display setup.</li>
+<li>Record unsupported or copy-only behavior clearly for Windows, Linux X11, and<br>
+Linux Wayland until those native helpers are production-ready.</li>
+</ul>
+      </div></section>
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+// Generates the static pages under docs/ that are derived from other sources:
+//
+//   changelog.html  <- GitHub releases
+//   notice.html     <- NOTICE
+//   license.html    <- LICENSE
+//   building.html   <- BUILDING.md
+//
+// Markdown is rendered through GitHub's own GFM endpoint, so release notes look
+// exactly as they do upstream without shipping a parser. Everything is baked at
+// build time: the published pages make no API calls.
+//
+// Usage: node scripts/build-site.mjs
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DOCS = join(ROOT, "docs");
+const REPO = "arcusis/Zerm";
+
+const gh = (args, input) =>
+  execFileSync("gh", args, {
+    input,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+
+const esc = (s) =>
+  String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/** Render GitHub-flavoured markdown to HTML via the GitHub API. */
+function renderMarkdown(text) {
+  if (!text || !text.trim()) return "";
+  const body = JSON.stringify({ text, mode: "gfm", context: REPO });
+  return gh(["api", "-X", "POST", "/markdown", "--input", "-"], body);
+}
+
+/**
+ * GitHub's renderer emits absolute anchors and bare issue links. Rewrite the
+ * noisy bits so the changelog reads as site content rather than a mirror.
+ */
+function tidy(html) {
+  return html
+    // Drop the octicon anchor GitHub injects before every heading
+    .replace(/<a[^>]*class="anchor"[^>]*>[\s\S]*?<\/a>/g, "")
+    // Open every outbound link in a new tab, without leaking the referrer
+    .replace(/<a href="(https?:\/\/[^"]+)"/g, '<a href="$1" rel="noopener noreferrer" target="_blank"')
+    .trim();
+}
+
+const NAV = [
+  ["./#models", "Models"],
+  ["./#dictation", "Dictation"],
+  ["./#read-aloud", "Read aloud"],
+  ["./privacy.html", "Privacy"],
+  ["./changelog.html", "Changelog"],
+];
+
+function shell({ title, description, current, hero, body, wide = false }) {
+  const nav = NAV.map(
+    ([href, label]) =>
+      `<a href="${href}"${current === label ? ' aria-current="page"' : ""}>${label}</a>`
+  ).join("\n          ");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>${esc(title)}</title>
+    <meta name="description" content="${esc(description)}" />
+    <meta name="theme-color" content="#0b0b0c" />
+    <meta property="og:title" content="${esc(title)}" />
+    <meta property="og:description" content="${esc(description)}" />
+    <meta property="og:image" content="./icon.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="icon" type="image/png" href="./icon.png" />
+    <link rel="apple-touch-icon" href="./icon.png" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <a class="skip" href="#main">Skip to content</a>
+
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="./" aria-label="Zerm home">
+          <img src="./icon.png" alt="" class="brand-logo" width="28" height="28" />
+          <span>Zerm</span>
+        </a>
+        <nav class="topbar-nav" aria-label="Primary">
+          ${nav}
+        </nav>
+        <div class="topbar-actions">
+          <a class="ghost-link" href="https://github.com/${REPO}">GitHub</a>
+          <a class="btn btn-light btn-sm" href="./#download">Download</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main" class="${wide ? "page page-wide" : "page"}">
+${hero}
+${body}
+    </main>
+
+    <footer class="site-foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img src="./icon.png" alt="" width="24" height="24" />
+          <span>Zerm</span>
+        </div>
+        <nav class="foot-links" aria-label="Footer">
+          <a href="./#download">Download</a>
+          <a href="./changelog.html">Changelog</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./building.html">Build from source</a>
+          <a href="./notice.html">Attribution</a>
+          <a href="./license.html">License</a>
+        </nav>
+        <p class="foot-legal">
+          © <span id="year"></span> Arcusis · GPLv3 · Based on VoiceInk by Beingpax
+        </p>
+      </div>
+    </footer>
+
+    <script src="./site.js" defer></script>
+  </body>
+</html>
+`;
+}
+
+function pageHero({ eyebrow, title, sub }) {
+  return `      <section class="page-hero">
+        <p class="eyebrow">${esc(eyebrow)}</p>
+        <h1>${esc(title)}</h1>
+        ${sub ? `<p class="lede">${sub}</p>` : ""}
+      </section>`;
+}
+
+const DATE = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+/**
+ * Sort key for a tag like v2.10.1 or v0.1.0-alpha.18. Release date is not
+ * usable here: backfilled releases carry the date they were published, not the
+ * date the work happened, which would float old versions to the top.
+ */
+function versionKey(tag) {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(tag);
+  if (!m) return [0, 0, 0, 0, tag];
+  const [, maj, min, patch, pre] = m;
+  // A pre-release sorts below the same version's final build
+  const preNum = pre ? Number((/(\d+)\s*$/.exec(pre) || [])[1] ?? 0) : Infinity;
+  return [Number(maj), Number(min), Number(patch), preNum, tag];
+}
+
+function compareVersions(a, b) {
+  const ka = versionKey(a.tag);
+  const kb = versionKey(b.tag);
+  for (let i = 0; i < 4; i++) if (ka[i] !== kb[i]) return kb[i] - ka[i];
+  return String(kb[4]).localeCompare(String(ka[4]));
+}
+
+function buildChangelog() {
+  const releases = JSON.parse(
+    gh([
+      "api",
+      `repos/${REPO}/releases`,
+      "--paginate",
+      "--jq",
+      "[.[] | {tag: .tag_name, name: .name, body: .body, draft: .draft, prerelease: .prerelease, published: .published_at, created: .created_at, assets: [.assets[] | {name: .name, size: .size, url: .browser_download_url}]}]",
+    ])
+  );
+
+  // Whichever release GitHub itself considers current
+  let latestTag = "";
+  try {
+    latestTag = gh(["api", `repos/${REPO}/releases/latest`, "--jq", ".tag_name"]).trim();
+  } catch {
+    /* no latest designated — fall back to the highest version */
+  }
+
+  const published = releases.filter((r) => !r.draft).sort(compareVersions);
+
+  if (!published.length) throw new Error("No published releases found");
+  if (!latestTag) latestTag = published[0].tag;
+
+  const entries = published
+    .map((r) => {
+      // created_at is when the release was cut; published_at is when the draft
+      // was flipped public, which for backfilled releases is meaninglessly late.
+      const stamp = r.created || r.published;
+      const when = stamp ? DATE.format(new Date(stamp)) : "";
+      const dmg = r.assets.find((a) => /\.dmg$/i.test(a.name));
+      const heading = (r.name || r.tag).replace(/^Zerm\s*/i, "").trim() || r.tag;
+
+      const badges = [
+        r.prerelease ? '<span class="rel-badge pre">Pre-release</span>' : "",
+        r.tag === latestTag ? '<span class="rel-badge now">Latest</span>' : "",
+      ]
+        .filter(Boolean)
+        .join("");
+
+      const download = dmg
+        ? `<a class="rel-dl" href="${dmg.url}">Download .dmg <span>${(dmg.size / 1048576).toFixed(1)} MB</span></a>`
+        : `<span class="rel-dl rel-dl-none">No build attached</span>`;
+
+      return `        <article class="rel" id="${esc(r.tag)}">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#${esc(r.tag)}">${esc(r.tag)}</a>
+            <time>${esc(when)}</time>
+            ${badges}
+            ${download}
+          </div>
+          <div class="rel-body">
+            <h2>${esc(heading)}</h2>
+            <div class="prose">
+${tidy(renderMarkdown(r.body))}
+            </div>
+          </div>
+        </article>`;
+    })
+    .join("\n");
+
+  const html = shell({
+    title: "Changelog — Zerm",
+    description:
+      "Every published Zerm release, with the full notes: what changed, what was fixed, and how much faster it got.",
+    current: "Changelog",
+    hero: pageHero({
+      eyebrow: `${published.length} releases`,
+      title: "Changelog",
+      sub: "Every published release, in full. Newest first.",
+    }),
+    body: `      <section class="rel-list">
+${entries}
+      </section>`,
+  });
+
+  writeFileSync(join(DOCS, "changelog.html"), html);
+  console.log(`changelog.html — ${published.length} releases`);
+}
+
+function buildDoc({ file, out, title, pageTitle, eyebrow, sub, plain = false }) {
+  const raw = readFileSync(join(ROOT, file), "utf8");
+  const inner = plain
+    ? `<pre class="plain">${esc(raw)}</pre>`
+    : tidy(renderMarkdown(raw));
+
+  const html = shell({
+    title,
+    description: sub.replace(/<[^>]+>/g, ""),
+    current: null,
+    hero: pageHero({ eyebrow, title: pageTitle, sub }),
+    body: `      <section class="doc"><div class="prose">
+${inner}
+      </div></section>`,
+  });
+
+  writeFileSync(join(DOCS, out), html);
+  console.log(`${out} — from ${file}`);
+}
+
+buildChangelog();
+
+buildDoc({
+  file: "NOTICE",
+  out: "notice.html",
+  title: "Attribution — Zerm",
+  pageTitle: "Attribution",
+  eyebrow: "Origin",
+  sub: "Zerm is a modified GPLv3 derivative of VoiceInk by Beingpax. This is the NOTICE file, verbatim.",
+  plain: true,
+});
+
+buildDoc({
+  file: "BUILDING.md",
+  out: "building.html",
+  title: "Build from source — Zerm",
+  pageTitle: "Build from source",
+  eyebrow: "For developers",
+  sub: "Requirements, build commands, and release tooling for the native macOS app.",
+});
+
+buildDoc({
+  file: "docs/native-writing-layer-verification.md",
+  out: "verification.html",
+  title: "Native writing layer verification — Zerm",
+  pageTitle: "Native writing layer verification",
+  eyebrow: "Engineering",
+  sub: "How the macOS insertion, permission, and paste behaviours are verified.",
+});
+
+buildDoc({
+  file: "LICENSE",
+  out: "license.html",
+  title: "License — Zerm",
+  pageTitle: "GNU General Public License v3",
+  eyebrow: "License",
+  sub: "Zerm is free software. The full license text follows.",
+  plain: true,
+});


### PR DESCRIPTION
Keeps people on the website instead of sending them to GitHub for release notes, attribution, licensing, and build instructions.

## New pages

| Page | Source |
|---|---|
| `changelog.html` | GitHub Releases (25 of them, full notes) |
| `notice.html` | `NOTICE` |
| `license.html` | `LICENSE` |
| `building.html` | `BUILDING.md` |
| `verification.html` | `docs/native-writing-layer-verification.md` |
| `privacy.html` | hand-written |

`scripts/build-site.mjs` generates all but the privacy page. Markdown goes through GitHub's own GFM endpoint, so release notes render exactly as they do upstream — tables, code blocks and all — without shipping a markdown parser. Output is fully static: **no runtime API calls, no rate limits.**

## Ordering fix

Publishing the backfilled `v1.0.4`, `v2.0.0` and `v2.0.1` stamped them with today's `published_at`, which sorted them above `v2.6.1` and moved the "Latest" badge onto v2.0.1. The changelog now sorts by semantic version, shows `created_at` as the date, and takes the "Latest" badge from whichever release GitHub designates.

## Staying current

The release workflow regenerates and commits these pages on every release publish or edit. `make site` does the same locally.

## Verification

All six pages in headless Chromium at 1440px: no console errors, no 4xx, no horizontal overflow, correct version ordering, `Latest` on v2.6.1 only.