### PR TITLE
Regenerate changelog with the backfilled DMGs

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -453,7 +453,7 @@ open /Applications/Zerm.app
             <a class="rel-tag" href="#v2.0.1">v2.0.1</a>
             <time>18 June 2026</time>
             
-            <span class="rel-dl rel-dl-none">No build attached</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.0.1/Zerm_2.0.1_aarch64.dmg">Download .dmg <span>22.6 MB</span></a>
           </div>
           <div class="rel-body">
             <h2>v2.0.1 — Read Aloud fixes &amp; instant feel</h2>
@@ -479,7 +479,7 @@ open /Applications/Zerm.app
             <a class="rel-tag" href="#v2.0.0">v2.0.0</a>
             <time>18 June 2026</time>
             
-            <span class="rel-dl rel-dl-none">No build attached</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.0.0/Zerm_2.0.0_aarch64.dmg">Download .dmg <span>22.6 MB</span></a>
           </div>
           <div class="rel-body">
             <h2>v2.0.0 — Read Aloud (TTS)</h2>
@@ -519,7 +519,7 @@ open /Applications/Zerm.app
             <a class="rel-tag" href="#v1.0.4">v1.0.4</a>
             <time>13 June 2026</time>
             
-            <span class="rel-dl rel-dl-none">No build attached</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.4/Zerm_1.0.4_aarch64.dmg">Download .dmg <span>12.6 MB</span></a>
           </div>
           <div class="rel-body">
             <h2>v1.0.4</h2>


### PR DESCRIPTION
v1.0.4, v2.0.0 and v2.0.1 were published earlier today without binaries — they had been sitting as drafts since June waiting on notarized builds. All three now have them.

Each DMG was built from that version's own commit under Xcode 26.6, signed with the Developer ID identity, notarized (`status: Accepted`), and stapled. Verified with `spctl`: all three come back `accepted source=Notarized Developer ID`.

Every one of the 25 published releases now has a downloadable build, so the changelog no longer shows "No build attached" anywhere.

**The appcast is deliberately untouched** — it still advertises 2.6.1 alone, so Sparkle cannot offer any of these older builds as an update.

One note: v1.0.4's version bump never landed in the project file, which still read `1.0.0`. It was stamped to `1.0.4` at build time so the app's reported version, the DMG filename and the tag all agree.