### PR TITLE
Give 2.8.0 real release notes

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -7,7 +7,17 @@
             <description><![CDATA[
                 <h3>What's New in v2.8.0</h3>
                 <ul>
-                    <li>Maintenance and stability improvements.</li>
+                    <li><b>New: the Recording tab.</b> Record a whole meeting &mdash; the room through your microphone, the call through your Mac &mdash; and read the transcript as it happens.</li>
+                    <li><b>Both sides, kept apart.</b> Your microphone and the call audio are recorded as separate tracks, so your side and theirs never get mixed together.</li>
+                    <li><b>Speaker identification.</b> Tells apart the people in the room with you, entirely on&nbsp;device.</li>
+                    <li><b>Summaries when the meeting ends,</b> with action items and chapters. Runs through local Ollama by default &mdash; your transcript never leaves the Mac unless you pick a cloud model.</li>
+                    <li><b>Offers to record</b> when Zoom, Teams, Meet, Signal, Slack or FaceTime opens.</li>
+                    <li><b>Import existing recordings</b> &mdash; wav, mp3, m4a, mp4, flac, ogg, aac, caf and aiff.</li>
+                    <li><b>Playback with a synced transcript.</b> Click any line to jump to the moment it was said.</li>
+                    <li><b>Survives a crash.</b> Transcript lines are saved as they arrive, so an interrupted meeting keeps everything up to the last few seconds.</li>
+                    <li><b>The dashboard no longer stutters</b> when you scroll it quickly.</li>
+                    <li><b>Fixed:</b> Apple&rsquo;s built&#8209;in dictation model now downloads missing language assets instead of failing with an error you could not act on.</li>
+                    <li><b>Fixed:</b> Power Mode&rsquo;s app picker no longer walks through symlinked folders, which could make it hang.</li>
                 </ul>
             ]]></description>
             <pubDate>Fri, 31 Jul 2026 19:26:41 +0000</pubDate>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,7 +7,17 @@
             <description><![CDATA[
                 <h3>What's New in v2.8.0</h3>
                 <ul>
-                    <li>Maintenance and stability improvements.</li>
+                    <li><b>New: the Recording tab.</b> Record a whole meeting &mdash; the room through your microphone, the call through your Mac &mdash; and read the transcript as it happens.</li>
+                    <li><b>Both sides, kept apart.</b> Your microphone and the call audio are recorded as separate tracks, so your side and theirs never get mixed together.</li>
+                    <li><b>Speaker identification.</b> Tells apart the people in the room with you, entirely on&nbsp;device.</li>
+                    <li><b>Summaries when the meeting ends,</b> with action items and chapters. Runs through local Ollama by default &mdash; your transcript never leaves the Mac unless you pick a cloud model.</li>
+                    <li><b>Offers to record</b> when Zoom, Teams, Meet, Signal, Slack or FaceTime opens.</li>
+                    <li><b>Import existing recordings</b> &mdash; wav, mp3, m4a, mp4, flac, ogg, aac, caf and aiff.</li>
+                    <li><b>Playback with a synced transcript.</b> Click any line to jump to the moment it was said.</li>
+                    <li><b>Survives a crash.</b> Transcript lines are saved as they arrive, so an interrupted meeting keeps everything up to the last few seconds.</li>
+                    <li><b>The dashboard no longer stutters</b> when you scroll it quickly.</li>
+                    <li><b>Fixed:</b> Apple&rsquo;s built&#8209;in dictation model now downloads missing language assets instead of failing with an error you could not act on.</li>
+                    <li><b>Fixed:</b> Power Mode&rsquo;s app picker no longer walks through symlinked folders, which could make it hang.</li>
                 </ul>
             ]]></description>
             <pubDate>Fri, 31 Jul 2026 19:26:41 +0000</pubDate>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -191,7 +191,22 @@ fi
 
 # Per-release notes for the Sparkle feed. Override per release, e.g.
 #   RELEASE_NOTES_HTML='                    <li>Fixed the thing.</li>' scripts/release.sh
-RELEASE_NOTES_HTML="${RELEASE_NOTES_HTML:-                    <li>Maintenance and stability improvements.</li>}"
+# Release notes shown in the in-app update dialog.
+#
+# There is deliberately no useful default. A silent fallback shipped 2.8.0 — a release
+# with a whole new Recording tab — describing itself to every user as "maintenance and
+# stability improvements". Better to stop and make the author write them.
+if [ -z "${RELEASE_NOTES_HTML:-}" ]; then
+    if [ -n "${RELEASE_NOTES_FILE:-}" ] && [ -f "${RELEASE_NOTES_FILE}" ]; then
+        RELEASE_NOTES_HTML="$(cat "${RELEASE_NOTES_FILE}")"
+    else
+        echo "error: no release notes supplied."
+        echo "  RELEASE_NOTES_HTML='<li>...</li>' scripts/release.sh"
+        echo "  RELEASE_NOTES_FILE=notes.html   scripts/release.sh"
+        echo "These are what users read in the update dialog; do not ship without them."
+        exit 1
+    fi
+fi
 
 PUB_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S +0000")
 APPCAST_OUT="$REPO_ROOT/docs/appcast.xml"


### PR DESCRIPTION
The in-app update dialog described 2.8.0 — a new Recording tab, speaker identification, meeting summaries — as *"Maintenance and stability improvements."*

`release.sh` defaults `RELEASE_NOTES_HTML` to that string and nothing warns when it is not set, so the placeholder shipped silently.

- Replaces the 2.8.0 appcast entry with the real notes.
- Makes `release.sh` **exit** rather than fall back to a placeholder. Notes come from `RELEASE_NOTES_HTML` or `RELEASE_NOTES_FILE`.

Only the `<description>` changes. The enclosure URL, length and `edSignature` are untouched, so anyone mid-download is unaffected.