### PR TITLE
fix(recording): give the Recording tab its own screens and a settings panel

### DIFF
--- a/Zerm/Views/Recording/MeetingDetailView.swift
+++ b/Zerm/Views/Recording/MeetingDetailView.swift
@@ -12,7 +12,12 @@ struct MeetingDetailView: View {
     @StateObject private var player = MeetingPlayer()
 
     private var lines: [MeetingRecordingStore.Sidecar.Line] { sidecar?.segments ?? [] }
-    private var activeLine: Int? { sidecar?.line(at: player.currentTime) }
+    /// Nothing is "playing now" before playback has started, so an untouched recording opens
+    /// with a plain transcript rather than its first line lit up as if it were being spoken.
+    private var activeLine: Int? {
+        guard player.isPlaying || player.currentTime > 0 else { return nil }
+        return sidecar?.line(at: player.currentTime)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -231,8 +236,15 @@ struct MeetingTranscriptRow: View {
     }
 
     /// Stable per-speaker colour so one voice reads the same way down the transcript.
+    ///
+    /// Not `hashValue`: Swift seeds string hashing per process, so the same voice came back a
+    /// different colour on every launch, and neighbouring labels could collide — "Speaker 1",
+    /// "Speaker 2" and "Speaker 3" all landed on the same pink. Folding the bytes is stable
+    /// across launches and puts labels that differ only in their last character on
+    /// consecutive palette entries, which is exactly the case that matters here.
     static func tint(_ label: String) -> Color {
         let palette: [Color] = [.blue, .purple, .orange, .green, .pink, .teal]
-        return palette[abs(label.hashValue) % palette.count]
+        let index = label.utf8.reduce(0) { ($0 &* 31 &+ Int($1)) % palette.count }
+        return palette[index]
     }
 }

--- a/Zerm/Views/Recording/MeetingLibraryView.swift
+++ b/Zerm/Views/Recording/MeetingLibraryView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+/// Every past recording, as its own screen.
+///
+/// A full-width list rather than a second sidebar: the Recording tab already sits inside the app's
+/// navigation sidebar, and nesting a split view inside it left both columns too narrow to read.
+struct MeetingLibraryView: View {
+    @ObservedObject var store: MeetingRecordingStore
+    let onOpen: (MeetingRecordingStore.Item) -> Void
+    let onImport: () -> Void
+
+    @State private var searchText = ""
+    @State private var pendingDeletion: MeetingRecordingStore.Item?
+
+    private var filtered: [MeetingRecordingStore.Item] {
+        let query = searchText.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return store.items }
+        return store.items.filter {
+            $0.title.localizedCaseInsensitiveContains(query)
+                || ($0.transcript?.localizedCaseInsensitiveContains(query) ?? false)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if !store.items.isEmpty {
+                searchBar
+                Divider()
+            }
+
+            if store.items.isEmpty {
+                emptyLibrary
+            } else if filtered.isEmpty {
+                noMatches
+            } else {
+                list
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .alert(
+            "Move this recording to the Trash?",
+            isPresented: Binding(get: { pendingDeletion != nil }, set: { if !$0 { pendingDeletion = nil } })
+        ) {
+            Button("Move to Trash", role: .destructive) {
+                if let item = pendingDeletion { store.delete(item) }
+                pendingDeletion = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text("The audio, transcript and summary all go with it.")
+        }
+    }
+
+    // MARK: - Search
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 12))
+                TextField("Search recordings and transcripts...", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 12))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(Color.secondary.opacity(0.08)))
+            .frame(maxWidth: .infinity)
+
+            Text("\(store.items.count) recording\(store.items.count == 1 ? "" : "s")")
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(spacing: 10) {
+                ForEach(filtered) { item in
+                    row(item)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+        }
+    }
+
+    private func row(_ item: MeetingRecordingStore.Item) -> some View {
+        Button {
+            onOpen(item)
+        } label: {
+            HStack(spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.12))
+                    Image(systemName: "waveform")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.accentColor)
+                }
+                .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+
+                    HStack(spacing: 10) {
+                        Label(MeetingRecordingView.clock(item.duration), systemImage: "clock")
+                        if item.speakerCount > 0 {
+                            Label("\(item.speakerCount)", systemImage: "person.2.fill")
+                        }
+                        Text(ByteCountFormatter.string(fromByteCount: item.totalBytes, countStyle: .file))
+                        if item.wasInterrupted {
+                            Label("recovered", systemImage: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                        }
+                    }
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .monospacedDigit()
+
+                    if let transcript = item.transcript, !transcript.isEmpty {
+                        Text(transcript)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                if item.summary != nil {
+                    Label("Summary", systemImage: "sparkles")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color.secondary.opacity(0.10)))
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .metricsCardSurface(cornerRadius: 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Show in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([item.folder])
+            }
+            Button("Move to Trash", role: .destructive) {
+                pendingDeletion = item
+            }
+        }
+    }
+
+    // MARK: - Empty states
+
+    private var emptyLibrary: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            CompactHeroSection(
+                icon: "rectangle.stack",
+                title: "No recordings yet",
+                description: "Meetings you record show up here with their audio, transcript and summary. You can also bring in audio you already have.",
+                maxDescriptionWidth: 420
+            )
+            Button("Import Recordings…", action: onImport)
+                .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var noMatches: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Text("No recording matches “\(searchText)”.")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Button("Clear search") { searchText = "" }
+                .buttonStyle(.link)
+                .font(.system(size: 12))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Zerm/Views/Recording/MeetingRecordingSettingsPanel.swift
+++ b/Zerm/Views/Recording/MeetingRecordingSettingsPanel.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Everything that configures a meeting recording, in one place.
+///
+/// These switches used to sit in the middle of the Recording tab, between the transport and the
+/// transcript, so the screen you use while a meeting runs was mostly controls you set once. They
+/// live here now, behind the same sliding settings panel Enhancement, Dictionary and Models use.
+struct MeetingRecordingSettingsPanel: View {
+    @AppStorage("meetingCaptureMicrophone") private var captureMicrophone = true
+    @AppStorage("meetingCaptureSystemAudio") private var captureSystemAudio = true
+    @AppStorage("meetingLiveTranscript") private var liveTranscript = true
+    @AppStorage("meetingIdentifySpeakers") private var identifySpeakers = true
+    @AppStorage("meetingSummarise") private var summariseAfterMeeting = true
+    @AppStorage("meetingAutoDetect") private var autoDetectMeetings = true
+
+    /// Capture settings cannot change mid-meeting — the tracks are already open.
+    let isRecording: Bool
+    let onImport: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Form {
+                if isRecording {
+                    Section {
+                        Label(
+                            "A recording is in progress. Capture settings apply to the next one.",
+                            systemImage: "record.circle.fill"
+                        )
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                    }
+                }
+
+                Section {
+                    Toggle(isOn: $captureMicrophone) {
+                        HStack(spacing: 4) {
+                            Text("Microphone")
+                            InfoTip("Records everyone in the room with you, through your input device.")
+                        }
+                    }
+                    .disabled(isRecording)
+
+                    Toggle(isOn: $captureSystemAudio) {
+                        HStack(spacing: 4) {
+                            Text("System Audio")
+                            InfoTip("Records everyone joining through the call, straight from your Mac's audio output.")
+                        }
+                    }
+                    .disabled(isRecording)
+
+                    if !captureMicrophone && !captureSystemAudio {
+                        Label("Pick at least one source, or there is nothing to record.",
+                              systemImage: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(.orange)
+                    }
+                } header: {
+                    Text("Capture")
+                } footer: {
+                    Text("Both are written as separate tracks, so you can tell your side from theirs.")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+
+                Section {
+                    Toggle(isOn: $liveTranscript) {
+                        HStack(spacing: 4) {
+                            Text("Transcribe While Recording")
+                            InfoTip("Lines appear as the meeting runs instead of only after it ends.")
+                        }
+                    }
+                    .disabled(isRecording)
+
+                    Toggle(isOn: $identifySpeakers) {
+                        HStack(spacing: 4) {
+                            Text("Identify Speakers")
+                            InfoTip("Separates the voices in the room and labels each transcript line. Needs the microphone.")
+                        }
+                    }
+                    .disabled(isRecording || !captureMicrophone)
+
+                    Toggle(isOn: $summariseAfterMeeting) {
+                        HStack(spacing: 4) {
+                            Text("Summarise When The Meeting Ends")
+                            InfoTip("Writes a summary, action items and chapters once the transcript is complete. Needs a transcript.")
+                        }
+                    }
+                    .disabled(!liveTranscript)
+                } header: {
+                    Text("Transcript")
+                }
+
+                Section {
+                    Toggle(isOn: $autoDetectMeetings) {
+                        HStack(spacing: 4) {
+                            Text("Offer To Record When A Call App Opens")
+                            InfoTip("Watches for Zoom, Meet, Teams and the like, and offers to start recording. Nothing starts on its own.")
+                        }
+                    }
+                } header: {
+                    Text("Automatic")
+                }
+
+                Section {
+                    Button("Import Recordings…") { onImport() }
+
+                    Button("Show Recordings Folder") {
+                        guard let root = try? MeetingRecordingSession.recordingsRoot() else { return }
+                        NSWorkspace.shared.activateFileViewerSelecting([root])
+                    }
+                } header: {
+                    Text("Library")
+                } footer: {
+                    Text("Recordings stay on this Mac. Nothing is uploaded.")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .toggleStyle(.switch)
+            .formStyle(.grouped)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text("Recording Settings")
+                .font(.headline)
+                .fontWeight(.semibold)
+                .foregroundColor(.primary)
+
+            Spacer()
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.1))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .help("Close")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(Color(NSColor.windowBackgroundColor))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+}

--- a/Zerm/Views/Recording/MeetingRecordingView.swift
+++ b/Zerm/Views/Recording/MeetingRecordingView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// The Recording tab: start a meeting, watch it come in, read the transcript as it lands.
+/// The Recording tab.
+///
+/// Two dedicated screens behind one segmented control: **Record**, which is only what you look at
+/// while a meeting runs, and **Library**, which is only past recordings. Everything you set once
+/// lives in the settings panel behind the gear, not in the middle of either screen.
 struct MeetingRecordingView: View {
     @EnvironmentObject private var engine: ZermEngine
     @StateObject private var controller: MeetingRecordingController
@@ -16,23 +20,50 @@ struct MeetingRecordingView: View {
     @AppStorage("meetingSummarise") private var summariseAfterMeeting = true
     @AppStorage("meetingAutoDetect") private var autoDetectMeetings = true
 
+    @State private var tab: Tab = .record
+    @State private var isShowingSettings = false
     @State private var importError: String?
-    /// nil = the live pane. Selecting a past recording swaps the detail side, exactly as the
-    /// live one behaves, so neither can drift into being a different kind of screen.
+    /// The recording opened inside the Library tab. nil means the list itself.
     @State private var selected: MeetingRecordingStore.Item?
+
+    enum Tab: String, CaseIterable, Identifiable {
+        case record = "Record"
+        case library = "Library"
+
+        var id: String { rawValue }
+        var icon: String {
+            switch self {
+            case .record: return "record.circle"
+            case .library: return "rectangle.stack.fill"
+            }
+        }
+    }
 
     init(engine: ZermEngine? = nil) {
         _controller = StateObject(wrappedValue: MeetingRecordingController(engine: engine))
     }
 
     var body: some View {
-        HSplitView {
-            sidebar
-                .frame(minWidth: 210, idealWidth: 240, maxWidth: 320)
-            detail
-                .frame(minWidth: 460, maxWidth: .infinity)
+        VStack(spacing: 0) {
+            topBar
+            Divider()
+
+            Group {
+                switch tab {
+                case .record: recordTab
+                case .library: libraryTab
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .background(Color(.windowBackgroundColor))
+        .background(Color(NSColor.controlBackgroundColor))
+        .slidingPanel(isPresented: $isShowingSettings, width: 400) {
+            MeetingRecordingSettingsPanel(
+                isRecording: controller.isRecording,
+                onImport: importRecording,
+                onDismiss: closeSettings
+            )
+        }
         .task {
             store.reload()
             if autoDetectMeetings { detector.start() }
@@ -41,97 +72,95 @@ struct MeetingRecordingView: View {
         .onChange(of: autoDetectMeetings) { _, enabled in
             enabled ? detector.start() : detector.stop()
         }
+        // A detected call is only actionable on the Record screen, so go there rather than
+        // showing a prompt the user cannot act on.
+        .onChange(of: detector.detected) { _, detection in
+            if detection != nil && !controller.isRecording { tab = .record }
+        }
     }
 
-    // MARK: - Sidebar
+    // MARK: - Top bar
 
-    private var sidebar: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
+    private var topBar: some View {
+        HStack(spacing: 12) {
+            if tab == .library, selected != nil {
                 Button {
                     selected = nil
                 } label: {
-                    Label(controller.isRecording ? "Recording…" : "New Recording",
-                          systemImage: controller.isRecording ? "record.circle.fill" : "plus.circle")
+                    Label("Library", systemImage: "chevron.left")
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(controller.isRecording ? .red : .accentColor)
                 }
                 .buttonStyle(.plain)
-                Spacer()
-                Button("Import…") { importRecording() }
-                    .buttonStyle(.link)
-                    .font(.system(size: 11))
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-
-            Divider()
-
-            if store.items.isEmpty {
-                Text("Recordings appear here.")
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
-                    .padding(14)
-                Spacer()
+                .foregroundColor(.accentColor)
+                .help("Back to all recordings")
             } else {
-                List(selection: $selected) {
-                    ForEach(store.items) { item in
-                        sidebarRow(item)
-                            .tag(item)
-                            .contextMenu {
-                                Button("Show in Finder") {
-                                    NSWorkspace.shared.activateFileViewerSelecting([item.folder])
-                                }
-                                Button("Move to Trash", role: .destructive) {
-                                    if selected == item { selected = nil }
-                                    store.delete(item)
-                                }
-                            }
+                Picker("", selection: $tab) {
+                    ForEach(Tab.allCases) { Text($0.rawValue).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 190)
+            }
+
+            Spacer()
+
+            // The one thing that has to stay visible from either screen: whether tape is rolling.
+            if controller.isRecording {
+                Button { tab = .record } label: {
+                    HStack(spacing: 6) {
+                        Circle().fill(Color.red).frame(width: 7, height: 7)
+                        Text(Self.clock(controller.session.elapsed))
+                            .font(.system(size: 12, weight: .medium))
+                            .monospacedDigit()
                     }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(Color.red.opacity(0.12)))
                 }
-                .listStyle(.sidebar)
+                .buttonStyle(.plain)
+                .foregroundColor(.red)
+                .help("Recording in progress")
             }
+
+            if tab == .library {
+                Button(action: importRecording) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "square.and.arrow.down")
+                        Text("Import")
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+                .help("Add existing audio files to your library")
+            }
+
+            Button {
+                withAnimation(.smooth(duration: 0.3)) { isShowingSettings.toggle() }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "gear")
+                    Text("Settings")
+                }
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(isShowingSettings ? .accentColor : .secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Capture sources, transcript and library settings")
+            .accessibilityLabel("Recording settings")
         }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(Color(NSColor.windowBackgroundColor))
     }
 
-    private func sidebarRow(_ item: MeetingRecordingStore.Item) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(item.title).font(.system(size: 12, weight: .medium)).lineLimit(1)
-            HStack(spacing: 6) {
-                Text(Self.clock(item.duration))
-                if item.speakerCount > 0 {
-                    Label("\(item.speakerCount)", systemImage: "person.2.fill")
-                }
-                if item.wasInterrupted {
-                    Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.orange)
-                }
-                Text(Self.size(item.totalBytes))
-            }
-            .font(.system(size: 9))
-            .foregroundColor(.secondary)
-            .monospacedDigit()
-        }
-        .padding(.vertical, 2)
-    }
+    // MARK: - Record tab
 
-    // MARK: - Detail
-
-    @ViewBuilder
-    private var detail: some View {
-        if let selected {
-            ScrollView {
-                MeetingDetailView(item: selected, sidecar: store.readSidecar(in: selected.folder))
-                    .padding(24)
-            }
-        } else {
-            liveDetail
-        }
-    }
-
-    private var liveDetail: some View {
+    private var recordTab: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                header
+                transportCard
+
                 if let message = importError {
                     banner(message, icon: "exclamationmark.triangle.fill", tint: .orange)
                 }
@@ -155,95 +184,123 @@ struct MeetingRecordingView: View {
                         secondary: ("Not now", { detector.dismiss() })
                     )
                 }
-                sources
+
                 if controller.isSummarising || controller.summary != nil || controller.summaryError != nil {
-                    summarySection
+                    summaryCard
                 }
-                transcriptSection
+
+                transcriptCard
             }
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
-    // MARK: - Header
+    private var transportCard: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 8) {
+                        if controller.isRecording {
+                            Circle().fill(Color.red).frame(width: 8, height: 8)
+                        }
+                        Text(controller.isRecording ? "Recording" : "Record a meeting")
+                            .font(.system(size: 20, weight: .semibold))
+                    }
 
-    private var header: some View {
-        HStack(alignment: .center, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(controller.isRecording ? "Recording" : "Record a meeting")
-                    .font(.system(size: 20, weight: .semibold))
-                Text(controller.isRecording
-                     ? Self.clock(controller.session.elapsed)
-                     : "Captures the room through your microphone and the call through your Mac's audio.")
-                    .font(.system(size: 13))
-                    .foregroundColor(.secondary)
-                    .monospacedDigit()
-            }
+                    if controller.isRecording {
+                        Text(Self.clock(controller.session.elapsed))
+                            .font(.system(size: 30, weight: .light))
+                            .monospacedDigit()
+                            .foregroundColor(.primary)
+                    } else {
+                        Text("Captures the room through your microphone and the call through your Mac's audio.")
+                            .font(.system(size: 13))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
 
-            Spacer()
+                Spacer()
 
-            if controller.isRecording {
-                levels
-            }
+                if controller.isRecording {
+                    HStack(spacing: 14) {
+                        if captureMicrophone {
+                            LevelMeter(label: "Mic", db: controller.session.microphoneLevelDb)
+                        }
+                        if captureSystemAudio {
+                            LevelMeter(label: "System", db: controller.session.systemAudioLevelDb)
+                        }
+                    }
+                }
 
-            Button(action: toggle) {
-                Text(controller.isRecording ? "Stop" : "Start")
+                Button(action: toggle) {
+                    HStack(spacing: 6) {
+                        Image(systemName: controller.isRecording ? "stop.fill" : "record.circle")
+                        Text(controller.isRecording ? "Stop" : "Start")
+                    }
                     .font(.system(size: 13, weight: .semibold))
-                    .frame(width: 68)
+                    .frame(width: 76)
                     .padding(.vertical, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(controller.isRecording ? .red : .accentColor)
+                .disabled(!hasSource)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(controller.isRecording ? .red : .accentColor)
-            .disabled(!captureMicrophone && !captureSystemAudio)
-        }
-        .padding(20)
-        .metricsCardSurface()
-    }
 
-    private var levels: some View {
-        HStack(spacing: 14) {
-            if captureMicrophone {
-                LevelMeter(label: "Mic", db: controller.session.microphoneLevelDb)
+            Divider()
+
+            if hasSource {
+                captureSummary
+            } else {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                    Text("No capture source is on, so there is nothing to record.")
+                        .font(.system(size: 12))
+                    Spacer()
+                    Button("Open Settings") {
+                        withAnimation(.smooth(duration: 0.3)) { isShowingSettings = true }
+                    }
+                    .buttonStyle(.link)
+                    .font(.system(size: 12, weight: .semibold))
+                }
             }
-            if captureSystemAudio {
-                LevelMeter(label: "System", db: controller.session.systemAudioLevelDb)
-            }
         }
-    }
-
-    // MARK: - Sources
-
-    private var sources: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Capture")
-                .font(.system(size: 13, weight: .semibold))
-
-            Toggle("Microphone — everyone in the room with you", isOn: $captureMicrophone)
-            Toggle("System audio — everyone joining through the call", isOn: $captureSystemAudio)
-            Toggle("Transcribe while recording", isOn: $liveTranscript)
-            Toggle("Identify speakers in the room", isOn: $identifySpeakers)
-                .disabled(!captureMicrophone)
-            Toggle("Summarise when the meeting ends", isOn: $summariseAfterMeeting)
-                .disabled(!liveTranscript)
-            Toggle("Offer to record when a call app opens", isOn: $autoDetectMeetings)
-
-            Text("Both are recorded as separate tracks, so you can tell your side from theirs.")
-                .font(.system(size: 11))
-                .foregroundColor(.secondary)
-        }
-        .toggleStyle(.switch)
-        .disabled(controller.isRecording)
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .metricsCardSurface()
     }
 
+    /// What the next recording will do, read-only. Changing any of it is the settings panel's job.
+    private var captureSummary: some View {
+        HStack(spacing: 8) {
+            if captureMicrophone { CaptureChip(icon: "mic.fill", label: "Microphone") }
+            if captureSystemAudio { CaptureChip(icon: "speaker.wave.2.fill", label: "System audio") }
+            if liveTranscript { CaptureChip(icon: "text.alignleft", label: "Live transcript") }
+            if liveTranscript && identifySpeakers && captureMicrophone {
+                CaptureChip(icon: "person.2.fill", label: "Speakers")
+            }
+            if liveTranscript && summariseAfterMeeting { CaptureChip(icon: "sparkles", label: "Summary") }
+
+            Spacer()
+
+            Button("Change") {
+                withAnimation(.smooth(duration: 0.3)) { isShowingSettings = true }
+            }
+            .buttonStyle(.link)
+            .font(.system(size: 11))
+            .disabled(controller.isRecording)
+        }
+    }
+
+    private var hasSource: Bool { captureMicrophone || captureSystemAudio }
+
     // MARK: - Transcript
 
-    private var transcriptSection: some View {
+    private var transcriptCard: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
+            HStack(spacing: 8) {
                 Text("Transcript")
                     .font(.system(size: 13, weight: .semibold))
                 if controller.isTranscribing && controller.isRecording {
@@ -266,15 +323,12 @@ struct MeetingRecordingView: View {
                         NSPasteboard.general.setString(controller.transcript, forType: .string)
                     }
                     .buttonStyle(.link)
+                    .font(.system(size: 12))
                 }
             }
 
             if controller.segments.isEmpty {
-                Text(controller.isRecording
-                     ? "Listening — the first lines appear once there is enough audio."
-                     : "Nothing recorded yet.")
-                    .font(.system(size: 12))
-                    .foregroundColor(.secondary)
+                emptyTranscript
             } else {
                 LazyVStack(alignment: .leading, spacing: 8) {
                     ForEach(controller.segments) { segment in
@@ -293,6 +347,13 @@ struct MeetingRecordingView: View {
                     Text("Saved \(Self.clock(recording.duration)) to \(recording.folder.lastPathComponent)")
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
+                    Spacer()
+                    Button("Open in Library") {
+                        selected = store.items.first { $0.folder == recording.folder }
+                        tab = .library
+                    }
+                    .buttonStyle(.link)
+                    .font(.system(size: 11))
                     Button("Show in Finder") {
                         NSWorkspace.shared.activateFileViewerSelecting([recording.folder])
                     }
@@ -306,10 +367,29 @@ struct MeetingRecordingView: View {
         .metricsCardSurface()
     }
 
+    @ViewBuilder
+    private var emptyTranscript: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if controller.isRecording && !liveTranscript {
+                Text("Transcribing while recording is off, so the transcript is not being written.")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            } else {
+                Text(controller.isRecording
+                     ? "Listening — the first lines appear once there is enough audio."
+                     : "Nothing recorded yet.")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 6)
+    }
+
     // MARK: - Summary
 
     @ViewBuilder
-    private var summarySection: some View {
+    private var summaryCard: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
                 Text("Summary")
@@ -379,7 +459,29 @@ struct MeetingRecordingView: View {
         .metricsCardSurface()
     }
 
+    // MARK: - Library tab
+
+    @ViewBuilder
+    private var libraryTab: some View {
+        if let item = selected {
+            ScrollView {
+                MeetingDetailView(item: item, sidecar: store.readSidecar(in: item.folder))
+                    .padding(24)
+            }
+        } else {
+            MeetingLibraryView(
+                store: store,
+                onOpen: { selected = $0 },
+                onImport: importRecording
+            )
+        }
+    }
+
     // MARK: - Actions
+
+    private func closeSettings() {
+        withAnimation(.smooth(duration: 0.3)) { isShowingSettings = false }
+    }
 
     private func toggle() {
         if controller.isRecording {
@@ -396,6 +498,7 @@ struct MeetingRecordingView: View {
                 }
             }
         } else {
+            tab = .record
             var sources: MeetingRecordingSession.Sources = []
             if captureMicrophone { sources.insert(.microphone) }
             if captureSystemAudio { sources.insert(.systemAudio) }
@@ -422,16 +525,6 @@ struct MeetingRecordingView: View {
         )
     }
 
-    private static func size(_ bytes: Int64) -> String {
-        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-    }
-
-    /// Stable per-speaker colour so the same voice reads the same way down the transcript.
-    private static func speakerTint(_ label: String) -> Color {
-        let palette: [Color] = [.blue, .purple, .orange, .green, .pink, .teal]
-        return palette[abs(label.hashValue) % palette.count]
-    }
-
     /// Adopts an existing audio file as a meeting, converting it to the recorder's own format
     /// so transcription, diarisation and summarising all work on it unchanged.
     private func importRecording() {
@@ -443,12 +536,20 @@ struct MeetingRecordingView: View {
         panel.message = "Choose recordings to add to your library"
 
         guard panel.runModal() == .OK else { return }
+        importError = nil
         for url in panel.urls {
             do {
-                try store.importRecording(from: url)
+                _ = try store.importRecording(from: url)
             } catch {
                 importError = error.localizedDescription
             }
+        }
+        if importError == nil {
+            closeSettings()
+            selected = nil
+            tab = .library
+        } else {
+            tab = .record
         }
     }
 
@@ -490,7 +591,7 @@ struct MeetingRecordingView: View {
         )
     }
 
-    private static func clock(_ interval: TimeInterval) -> String {
+    static func clock(_ interval: TimeInterval) -> String {
         let total = Int(interval.rounded())
         let hours = total / 3600
         let minutes = (total % 3600) / 60
@@ -498,6 +599,23 @@ struct MeetingRecordingView: View {
         return hours > 0
             ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
             : String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+/// One read-only fact about what the next recording will capture.
+private struct CaptureChip: View {
+    let icon: String
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon).font(.system(size: 9))
+            Text(label).font(.system(size: 10, weight: .medium))
+        }
+        .foregroundColor(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(Color.secondary.opacity(0.10)))
     }
 }
 


### PR DESCRIPTION
Closes #294

## What was wrong

- `MeetingRecordingView` nested an `HSplitView` inside `ContentView`'s `NavigationSplitView`, in a window pinned to `.frame(width: 950)`. Two sidebars competed for the same width and the detail column was left too narrow to read.
- Six capture switches sat between the transport and the transcript — set-once configuration on the screen you watch during a meeting.
- Recording had no Settings button, unlike Enhancement, Dictionary and Models, so there was nowhere for those switches to live.
- Past recordings were a cramped list in the inner sidebar: no search, no real empty state.

## What changed

**`MeetingRecordingView`** — top bar with a segmented Record / Library control, a live recording pill (red dot plus elapsed time, click to jump back to Record), Import on the Library screen, and a `gear + Settings` button matching the pattern in `EnhancementSettingsView`.

- **Record** is only live state: transport card with status dot, timer, level meters and Start/Stop; a read-only row of chips saying what the next recording will capture; banners; transcript; summary. No switches.
- **Library** is `MeetingLibraryView`, or the selected recording's `MeetingDetailView` with a back button in the top bar.

**`MeetingLibraryView`** (new) — full-width card list: waveform tile, title, duration / speakers / size / recovered flag, a transcript preview line, a Summary chip and a chevron. Search across titles and transcripts, recording count, context menu for Finder and Trash with a confirmation, and a hero empty state with an Import call to action.

**`MeetingRecordingSettingsPanel`** (new) — the app's standard sliding panel, `Form` with `.grouped` style like every other settings panel. Sections: Capture (microphone, system audio, warning when both are off), Transcript (live, speakers, summarise, with dependency-based disabling), Automatic (call-app detection), Library (Import, Show Recordings Folder). Capture toggles lock mid-recording and say why.

Since the toggles left the Record screen, the transport card now explains inline when no capture source is on and links to the settings panel, instead of showing a disabled Start button with no explanation.

## Verification

- `make build` — BUILD SUCCEEDED
- `xcodebuild test -only-testing:ZermTests/MeetingRecordingTests` — all pass

Not visually checked in a running app yet; the changes are view-layer only and the build is the gate that ran.