### PR TITLE
docs: publish Zerm 2.8.2 changelog

### DIFF
--- a/docs/building.html
+++ b/docs/building.html
@@ -127,9 +127,37 @@ rejects the app on other Macs ("Zerm is damaged and can't be opened" /<br>
 <div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">make release            <span class="pl-c"><span class="pl-c">#</span> or: scripts/release.sh</span></pre></div>
 <p dir="auto">This builds the Release configuration, signs the app with Developer ID and the<br>
 hardened runtime, notarizes app and DMG with Apple, staples the tickets, and<br>
-verifies the result with <code class="notranslate">spctl</code>. The DMG lands in the repo root as<br>
-<code class="notranslate">Zerm_X.Y.Z_aarch64.dmg</code>, ready for <code class="notranslate">gh release upload</code>.</p>
+verifies the result with <code class="notranslate">spctl</code>. It exports both exact GitHub Release assets in<br>
+the repo root: <code class="notranslate">Zerm_&lt;release-label&gt;_aarch64.dmg</code> and the Sparkle enclosure<br>
+<code class="notranslate">Zerm-&lt;release-label&gt;-macos.zip</code>. Upload both with the command printed by the<br>
+script.</p>
+<p dir="auto">By default the release label is the Xcode project's <code class="notranslate">MARKETING_VERSION</code> and the<br>
+tag is <code class="notranslate">v&lt;MARKETING_VERSION&gt;</code>. If the approved GitHub release needs a distinct<br>
+three- or four-component label, set both explicitly:</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">RELEASE_LABEL=A.B.C.D RELEASE_TAG=vA.B.C.D scripts/release.sh</pre></div>
+<p dir="auto">This changes the GitHub tag, filenames, appcast title and enclosure URL only.<br>
+The app and <code class="notranslate">sparkle:shortVersionString</code> still use Apple's three-component<br>
+<code class="notranslate">MARKETING_VERSION</code>; <code class="notranslate">sparkle:version</code> uses the strictly increasing<br>
+<code class="notranslate">CURRENT_PROJECT_VERSION</code>, which controls update ordering. The script rejects a<br>
+noncanonical tag/label pair or a build number that is not newer than the current<br>
+published appcast.</p>
+<p dir="auto">To sign and notarize a Release app built on the Office Mac without rebuilding<br>
+on the signing Mac, copy the app outside <code class="notranslate">.release-build</code> and run the script<br>
+directly (not through <code class="notranslate">make release</code>, whose <code class="notranslate">setup</code> prerequisite builds native<br>
+dependencies):</p>
+<div class="highlight highlight-source-shell" dir="auto"><pre class="notranslate">PREBUILT_APP=/path/to/Zerm.app \
+  RELEASE_LABEL=A.B.C.D RELEASE_TAG=vA.B.C.D \
+  scripts/release.sh</pre></div>
+<p dir="auto">The script fails before signing if the bundle identifier, project version,<br>
+build number or arm64 executable does not match, and validates the staged copy<br>
+again. Sparkle signing material and release notes are mandatory for a real run.</p>
 <p dir="auto"><code class="notranslate">SKIP_NOTARIZE=1 scripts/release.sh</code> does a signing-only dry run.</p>
+<p dir="auto">After packaging, commit the generated <code class="notranslate">docs/appcast.xml</code> with the release source,<br>
+push the tag, create a draft GitHub Release, and upload both exact assets. Run<br>
+the Release workflow manually against that draft tag before publishing. The<br>
+workflow cross-checks the tag and filenames against the tagged appcast, Xcode<br>
+project and ZIP bundle identity; its <code class="notranslate">released</code> run is a post-publication<br>
+verification, not a substitute for the draft gate.</p>
 <h3 dir="auto">After publishing the GitHub Release</h3>
 <p dir="auto">The site changelog is generated from the <strong>published</strong> GitHub Releases, so it can<br>
 only be rebuilt once the release exists:</p>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -40,16 +40,102 @@
 
     <main id="main" class="page">
       <section class="page-hero">
-        <p class="eyebrow">27 releases</p>
+        <p class="eyebrow">30 releases</p>
         <h1>Changelog</h1>
         <p class="lede">Every published release, in full. Newest first.</p>
       </section>
       <section class="rel-list">
+        <article class="rel" id="v2.8.2">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.8.2">v2.8.2</a>
+            <time>14 August 2026</time>
+            <span class="rel-badge now">Latest</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.2/Zerm_2.8.2_aarch64.dmg">Download .dmg <span>28.2 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.8.2</h2>
+            <div class="prose">
+<h2 dir="auto">What’s new</h2>
+<ul dir="auto">
+<li>Rebuilt Meetings with explicit Room, selected-app, and all-system-audio capture; durable recovery; speaker attribution; and synchronized playback.</li>
+<li>Improved Hebrew and automatic language transcription across local and supported cloud models.</li>
+<li>Rebuilt Read Aloud with Retell, Summarize, Explain, and Simplify modes, local history, and improved Hebrew voice support.</li>
+<li>Fixed repeated clipboard operations, safer in-place replacement, and clearer paste/refinement feedback.</li>
+<li>Improved technical terminology for software, cloud, codecs, models, and CLI tools.</li>
+<li>Reduced local-AI memory pressure with the official memory-efficient Gemma 4 E2B model, idle unloading, and hardware-aware recommendations. Larger models remain manual opt-ins.</li>
+<li>Reorganized navigation, Settings, permissions, and recording preflight for a clearer native macOS workflow.</li>
+<li>Added stability, privacy, accessibility, localization, and release-infrastructure fixes throughout the app.</li>
+</ul>
+<h2 dir="auto">Compatibility</h2>
+<ul dir="auto">
+<li>macOS 14.4 or later</li>
+<li>Apple silicon (arm64)</li>
+</ul>
+<p dir="auto">Zerm remains local-first. Audio is sent off-device only when you explicitly select a cloud transcription or AI provider.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.8.1">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.8.1">v2.8.1</a>
+            <time>1 August 2026</time>
+
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.1/Zerm_2.8.1_aarch64.dmg">Download .dmg <span>27.5 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>v2.8.1</h2>
+            <div class="prose">
+<h2 dir="auto">What's new</h2>
+<ul dir="auto">
+<li>The Recording tab is rebuilt as two dedicated screens — <strong>Record</strong> for the meeting in progress, <strong>Library</strong> for everything you have recorded — instead of one crowded pane.</li>
+<li>Capture, transcript and automation settings moved into their own panel behind a <strong>Settings</strong> button, so the recording screen shows only what is happening now.</li>
+<li>The Library is searchable, and shows each recording's length, speakers, size and summary at a glance. Open any of them for playback with the transcript following along.</li>
+<li>Speaker colours in a transcript are stable and distinct — the same voice keeps its colour between launches, instead of every speaker coming out the same shade.</li>
+<li>A transcript no longer highlights its first line as if it were playing before you press play.</li>
+</ul>
+<h2 dir="auto">Install</h2>
+<p dir="auto">Download <code class="notranslate">Zerm_2.8.1_aarch64.dmg</code> (Apple silicon). The build is Developer ID signed and notarised by Apple.</p>
+<p dir="auto">Existing installs update themselves through Sparkle.</p>
+            </div>
+          </div>
+        </article>
+        <article class="rel" id="v2.8.0">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.8.0">v2.8.0</a>
+            <time>31 July 2026</time>
+
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.0/Zerm_2.8.0_aarch64.dmg">Download .dmg <span>27.3 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.8.0 — Meeting recording</h2>
+            <div class="prose">
+<p dir="auto">Records whole conversations — the room through your microphone, the call through your Mac — and transcribes them as they happen.</p>
+<h2 dir="auto">New: the Recording tab</h2>
+<ul dir="auto">
+<li><strong>Two separate tracks.</strong> Your side and theirs are captured independently, not mixed, so the transcript can tell them apart and either side can be re-transcribed on its own.</li>
+<li><strong>Live transcription</strong> while the meeting is still running, using whichever model you already use for dictation.</li>
+<li><strong>Speaker identification</strong> for the people in the room with you, on-device.</li>
+<li><strong>Summaries</strong> with action items and chapters when the meeting ends, through local Ollama by default — a meeting transcript never leaves your Mac unless you choose a cloud model.</li>
+<li><strong>Offers to record</strong> when Zoom, Teams, Meet, Signal, Slack or FaceTime opens.</li>
+<li><strong>Import</strong> existing recordings — wav, mp3, m4a, mp4, flac, ogg, aac, caf, aiff.</li>
+<li><strong>Playback with a synced transcript.</strong> Click any line to jump to the moment it was said.</li>
+<li><strong>Survives a crash.</strong> Transcript lines are written as they land, so an interrupted meeting keeps everything up to the last few seconds.</li>
+</ul>
+<p dir="auto">System audio is captured with a Core Audio process tap: no driver to install and no screen-recording permission. It does need the Audio Recording permission, which macOS will ask for the first time you record a call.</p>
+<h2 dir="auto">Also in this release</h2>
+<ul dir="auto">
+<li>The dashboard no longer stutters when scrolled quickly.</li>
+<li>Power Mode's app picker no longer walks through symlinked directories, which could make it hang.</li>
+<li>Apple's built-in dictation model now downloads missing language assets instead of failing with an error you could not act on.</li>
+</ul>
+            </div>
+          </div>
+        </article>
         <article class="rel" id="v2.7.1">
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.7.1">v2.7.1</a>
             <time>30 July 2026</time>
-            <span class="rel-badge now">Latest</span>
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.7.1/Zerm_2.7.1_aarch64.dmg">Download .dmg <span>26.9 MB</span></a>
           </div>
           <div class="rel-body">
@@ -78,7 +164,7 @@
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.7.0">v2.7.0</a>
             <time>29 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.7.0/Zerm_2.7.0_aarch64.dmg">Download .dmg <span>26.7 MB</span></a>
           </div>
           <div class="rel-body">
@@ -116,7 +202,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.6.1">v2.6.1</a>
             <time>27 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.6.1/Zerm_2.6.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -167,7 +253,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.5.1">v2.5.1</a>
             <time>18 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.5.1/Zerm_2.5.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -187,7 +273,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.5.0">v2.5.0</a>
             <time>17 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.5.0/Zerm_2.5.0_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -214,7 +300,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.4.0">v2.4.0</a>
             <time>17 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.4.0/Zerm_2.4.0_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -248,7 +334,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.3">v2.3.3</a>
             <time>15 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.3/Zerm_2.3.3_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -276,7 +362,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.2">v2.3.2</a>
             <time>13 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.2/Zerm_2.3.2_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -296,7 +382,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.1">v2.3.1</a>
             <time>13 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.1/Zerm_2.3.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -327,7 +413,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.0">v2.3.0</a>
             <time>13 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.0/Zerm_2.3.0_aarch64.dmg">Download .dmg <span>26.4 MB</span></a>
           </div>
           <div class="rel-body">
@@ -376,7 +462,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.2.0">v2.2.0</a>
             <time>13 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.2.0/Zerm_2.2.0_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -406,7 +492,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.3">v2.1.3</a>
             <time>2 July 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.3/Zerm_2.1.3_aarch64.dmg">Download .dmg <span>26.4 MB</span></a>
           </div>
           <div class="rel-body">
@@ -433,7 +519,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.2">v2.1.2</a>
             <time>29 June 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.2/Zerm_2.1.2_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -461,7 +547,7 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.1">v2.1.1</a>
             <time>27 June 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.1/Zerm_2.1.1_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -487,7 +573,7 @@ then open it again.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.0">v2.1.0</a>
             <time>21 June 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.0/Zerm_2.1.0_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -520,7 +606,7 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.0.1">v2.0.1</a>
             <time>18 June 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.0.1/Zerm_2.0.1_aarch64.dmg">Download .dmg <span>22.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -546,7 +632,7 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.0.0">v2.0.0</a>
             <time>18 June 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.0.0/Zerm_2.0.0_aarch64.dmg">Download .dmg <span>22.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -586,7 +672,7 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.4">v1.0.4</a>
             <time>13 June 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.4/Zerm_1.0.4_aarch64.dmg">Download .dmg <span>12.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -609,7 +695,7 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.3">v1.0.3</a>
             <time>22 May 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.3/Zerm_1.0.3_aarch64.dmg">Download .dmg <span>14.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -650,7 +736,7 @@ runs.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.2">v1.0.2</a>
             <time>22 May 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.2/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -691,7 +777,7 @@ runs.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.1">v1.0.1</a>
             <time>22 May 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.1/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -732,7 +818,7 @@ runs.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.0">v1.0.0</a>
             <time>27 April 2026</time>
-            
+
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.0/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
           </div>
           <div class="rel-body">


### PR DESCRIPTION
## Summary

- regenerate the public changelog after publishing Zerm 2.8.2
- include the previously missing 2.8.0 and 2.8.1 GitHub releases
- regenerate the build-from-source page from the current release documentation

## Verification

- `node scripts/build-site.mjs`
- `git diff --check`
- generated HTML basic validation
- the v2.8.2 release tag/assets/appcast/ZIP identity validator already passed in release run 31846663010

Merging this PR clears the release workflow's derived-site drift gate. It does not change the shipped app or release assets.
