### PR TITLE
fix: make changelog generation idempotent

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -79,7 +79,6 @@
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.8.1">v2.8.1</a>
             <time>1 August 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.1/Zerm_2.8.1_aarch64.dmg">Download .dmg <span>27.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -103,7 +102,6 @@
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.8.0">v2.8.0</a>
             <time>31 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.0/Zerm_2.8.0_aarch64.dmg">Download .dmg <span>27.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -135,7 +133,6 @@
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.7.1">v2.7.1</a>
             <time>30 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.7.1/Zerm_2.7.1_aarch64.dmg">Download .dmg <span>26.9 MB</span></a>
           </div>
           <div class="rel-body">
@@ -164,7 +161,6 @@
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.7.0">v2.7.0</a>
             <time>29 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.7.0/Zerm_2.7.0_aarch64.dmg">Download .dmg <span>26.7 MB</span></a>
           </div>
           <div class="rel-body">
@@ -202,7 +198,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.6.1">v2.6.1</a>
             <time>27 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.6.1/Zerm_2.6.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -253,7 +248,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.5.1">v2.5.1</a>
             <time>18 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.5.1/Zerm_2.5.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -273,7 +267,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.5.0">v2.5.0</a>
             <time>17 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.5.0/Zerm_2.5.0_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -300,7 +293,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.4.0">v2.4.0</a>
             <time>17 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.4.0/Zerm_2.4.0_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -334,7 +326,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.3">v2.3.3</a>
             <time>15 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.3/Zerm_2.3.3_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -362,7 +353,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.2">v2.3.2</a>
             <time>13 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.2/Zerm_2.3.2_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -382,7 +372,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.1">v2.3.1</a>
             <time>13 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.1/Zerm_2.3.1_aarch64.dmg">Download .dmg <span>26.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -413,7 +402,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.3.0">v2.3.0</a>
             <time>13 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.3.0/Zerm_2.3.0_aarch64.dmg">Download .dmg <span>26.4 MB</span></a>
           </div>
           <div class="rel-body">
@@ -462,7 +450,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.2.0">v2.2.0</a>
             <time>13 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.2.0/Zerm_2.2.0_aarch64.dmg">Download .dmg <span>26.5 MB</span></a>
           </div>
           <div class="rel-body">
@@ -492,7 +479,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.3">v2.1.3</a>
             <time>2 July 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.3/Zerm_2.1.3_aarch64.dmg">Download .dmg <span>26.4 MB</span></a>
           </div>
           <div class="rel-body">
@@ -519,7 +505,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.2">v2.1.2</a>
             <time>29 June 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.2/Zerm_2.1.2_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -547,7 +532,6 @@ Signed with a Developer ID certificate and notarized by Apple.</p>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.1">v2.1.1</a>
             <time>27 June 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.1/Zerm_2.1.1_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -573,7 +557,6 @@ then open it again.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.1.0">v2.1.0</a>
             <time>21 June 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.1.0/Zerm_2.1.0_aarch64.dmg">Download .dmg <span>26.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -606,7 +589,6 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.0.1">v2.0.1</a>
             <time>18 June 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.0.1/Zerm_2.0.1_aarch64.dmg">Download .dmg <span>22.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -632,7 +614,6 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.0.0">v2.0.0</a>
             <time>18 June 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.0.0/Zerm_2.0.0_aarch64.dmg">Download .dmg <span>22.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -672,7 +653,6 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.4">v1.0.4</a>
             <time>13 June 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.4/Zerm_1.0.4_aarch64.dmg">Download .dmg <span>12.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -695,7 +675,6 @@ open /Applications/Zerm.app
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.3">v1.0.3</a>
             <time>22 May 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.3/Zerm_1.0.3_aarch64.dmg">Download .dmg <span>14.6 MB</span></a>
           </div>
           <div class="rel-body">
@@ -736,7 +715,6 @@ runs.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.2">v1.0.2</a>
             <time>22 May 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.2/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -777,7 +755,6 @@ runs.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.1">v1.0.1</a>
             <time>22 May 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.1/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
           </div>
           <div class="rel-body">
@@ -818,7 +795,6 @@ runs.</li>
           <div class="rel-meta">
             <a class="rel-tag" href="#v1.0.0">v1.0.0</a>
             <time>27 April 2026</time>
-
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v1.0.0/Zerm_1.0.0_aarch64.dmg">Download .dmg <span>4.3 MB</span></a>
           </div>
           <div class="rel-body">

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -223,6 +223,7 @@ function buildChangelog() {
       ]
         .filter(Boolean)
         .join("");
+      const badgesLine = badges ? `            ${badges}\n` : "";
 
       const download = dmg
         ? `<a class="rel-dl" href="${dmg.url}">Download .dmg <span>${(dmg.size / 1048576).toFixed(1)} MB</span></a>`
@@ -232,8 +233,7 @@ function buildChangelog() {
           <div class="rel-meta">
             <a class="rel-tag" href="#${esc(r.tag)}">${esc(r.tag)}</a>
             <time>${esc(when)}</time>
-            ${badges}
-            ${download}
+${badgesLine}            ${download}
           </div>
           <div class="rel-body">
             <h2>${esc(heading)}</h2>


### PR DESCRIPTION
## Summary

- stop the release-site generator from emitting whitespace-only badge lines
- regenerate `docs/changelog.html` from the fixed template
- make post-release site comparison deterministic and `git diff --check` clean

## Verification

- ran `node scripts/build-site.mjs` twice
- `docs/changelog.html` SHA-256 was identical before and after the second run
- `git diff --check` passed
- Zerm 2.8.2 tag/assets/appcast/ZIP validation is already green

This changes only the site generator and generated changelog, not the shipped app or release artifacts.
