### PR TITLE
docs: publish Zerm 2.8.3 changelog

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -40,16 +40,42 @@
 
     <main id="main" class="page">
       <section class="page-hero">
-        <p class="eyebrow">30 releases</p>
+        <p class="eyebrow">31 releases</p>
         <h1>Changelog</h1>
         <p class="lede">Every published release, in full. Newest first.</p>
       </section>
       <section class="rel-list">
+        <article class="rel" id="v2.8.3">
+          <div class="rel-meta">
+            <a class="rel-tag" href="#v2.8.3">v2.8.3</a>
+            <time>17 August 2026</time>
+            <span class="rel-badge now">Latest</span>
+            <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.3/Zerm_2.8.3_aarch64.dmg">Download .dmg <span>28.2 MB</span></a>
+          </div>
+          <div class="rel-body">
+            <h2>2.8.3</h2>
+            <div class="prose">
+<h2 dir="auto">What’s new</h2>
+<ul dir="auto">
+<li>Recordings are saved even if transcription or AI fails. Retry from History.</li>
+<li>English and mixed dictation no longer collapse to Hebrew. Enhancement keeps the original script.</li>
+<li>Instant + Refine pastes once. Enhanced no longer copies the selection after you finish speaking.</li>
+<li>Enhancement defaults to Qwen3. Gemma stays on Read Aloud.</li>
+<li>Word replacements respect Unicode word boundaries. Microphone detection no longer under-allocates the Core Audio buffer list.</li>
+</ul>
+<h2 dir="auto">Compatibility</h2>
+<ul dir="auto">
+<li>macOS 14.4 or later</li>
+<li>Apple silicon (arm64)</li>
+</ul>
+<p dir="auto">Zerm remains local-first. Audio leaves the Mac only when you choose a cloud provider.</p>
+            </div>
+          </div>
+        </article>
         <article class="rel" id="v2.8.2">
           <div class="rel-meta">
             <a class="rel-tag" href="#v2.8.2">v2.8.2</a>
             <time>14 August 2026</time>
-            <span class="rel-badge now">Latest</span>
             <a class="rel-dl" href="https://github.com/arcusis/Zerm/releases/download/v2.8.2/Zerm_2.8.2_aarch64.dmg">Download .dmg <span>28.2 MB</span></a>
           </div>
           <div class="rel-body">


### PR DESCRIPTION
Regenerates docs/changelog.html from the published v2.8.3 GitHub release so the site matches Sparkle and the Download button.