### PR TITLE
chore: publish the 2.8.4 appcast entry

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,22 +3,26 @@
     <channel>
         <title>Zerm</title>
         <item>
-            <title>2.8.3</title>
+            <title>2.8.4</title>
             <description><![CDATA[
-                <h3>What's New in v2.8.3</h3>
+                <h3>What's New in v2.8.4</h3>
                 <ul>
-                    <li>Recordings are saved even if transcription or AI fails. Retry from History.</li>
-                    <li>English and mixed dictation no longer collapse to Hebrew. Enhancement keeps the original script.</li>
-                    <li>Instant + Refine pastes once. Enhanced no longer copies the selection after you finish speaking.</li>
-                    <li>Enhancement defaults to Qwen3. Gemma stays on Read Aloud.</li>
-                    <li>Word replacements respect Unicode word boundaries. Microphone detection no longer under-allocates the Core Audio buffer list.</li>
+                    <li>AI enhancement works again. On-device enhancement was returning nothing at all and pasting the raw transcript instead.</li>
+                    <li>History rows that appeared blank now show their text. No transcript was ever lost — the words were always there, the row just drew the empty enhancement over them. Affected rows are repaired when you launch this version.</li>
+                    <li>Enhancement is about 3.5x faster. Short dictation now finishes in roughly a tenth of a second.</li>
+                    <li>Mixed-language dictation keeps every word in the language it was spoken in. English, Hebrew and Russian in one sentence stay that way.</li>
+                    <li>Enhancement no longer answers a question you dictated, and no longer pastes stray markup into your document.</li>
+                    <li>The on-device model list has been rebuilt on measurement. Models that produced empty or unusable output are gone, and the ones that did not work are removed from your Mac to reclaim the space.</li>
+                    <li>Meeting recordings capture the call correctly. The call track could previously end up half its real length and drift out of sync with your microphone.</li>
+                    <li>Meetings transcribe after you stop instead of during the call, so recording no longer competes with everything else for CPU.</li>
+                    <li>The installer window is properly branded.</li>
                 </ul>
             ]]></description>
-            <pubDate>Mon, 17 Aug 2026 10:28:37 +0000</pubDate>
-            <sparkle:version>283</sparkle:version>
-            <sparkle:shortVersionString>2.8.3</sparkle:shortVersionString>
+            <pubDate>Fri, 21 Aug 2026 19:16:36 +0000</pubDate>
+            <sparkle:version>284</sparkle:version>
+            <sparkle:shortVersionString>2.8.4</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/arcusis/Zerm/releases/download/v2.8.3/Zerm-2.8.3-macos.zip" length="25297705" type="application/octet-stream" sparkle:edSignature="MwMBLFxoAwkzXjCjf0FeZVlChh9cCWWFagr+cWzbA7xbleTNz03J5zpGXWflqcYavoINme1FXEtthVi1u02FAA=="/>
+            <enclosure url="https://github.com/arcusis/Zerm/releases/download/v2.8.4/Zerm-2.8.4-macos.zip" length="25280486" type="application/octet-stream" sparkle:edSignature="f0GYq09pd2dFk7CVKLjqONGCfWITAFrht/gq9kFHeLnllKtCBo0LWQjERW/lY1AURArfTvtNTbzwtezhh9ABDQ=="/>
         </item>
     </channel>
 </rss>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -3,22 +3,26 @@
     <channel>
         <title>Zerm</title>
         <item>
-            <title>2.8.3</title>
+            <title>2.8.4</title>
             <description><![CDATA[
-                <h3>What's New in v2.8.3</h3>
+                <h3>What's New in v2.8.4</h3>
                 <ul>
-                    <li>Recordings are saved even if transcription or AI fails. Retry from History.</li>
-                    <li>English and mixed dictation no longer collapse to Hebrew. Enhancement keeps the original script.</li>
-                    <li>Instant + Refine pastes once. Enhanced no longer copies the selection after you finish speaking.</li>
-                    <li>Enhancement defaults to Qwen3. Gemma stays on Read Aloud.</li>
-                    <li>Word replacements respect Unicode word boundaries. Microphone detection no longer under-allocates the Core Audio buffer list.</li>
+                    <li>AI enhancement works again. On-device enhancement was returning nothing at all and pasting the raw transcript instead.</li>
+                    <li>History rows that appeared blank now show their text. No transcript was ever lost — the words were always there, the row just drew the empty enhancement over them. Affected rows are repaired when you launch this version.</li>
+                    <li>Enhancement is about 3.5x faster. Short dictation now finishes in roughly a tenth of a second.</li>
+                    <li>Mixed-language dictation keeps every word in the language it was spoken in. English, Hebrew and Russian in one sentence stay that way.</li>
+                    <li>Enhancement no longer answers a question you dictated, and no longer pastes stray markup into your document.</li>
+                    <li>The on-device model list has been rebuilt on measurement. Models that produced empty or unusable output are gone, and the ones that did not work are removed from your Mac to reclaim the space.</li>
+                    <li>Meeting recordings capture the call correctly. The call track could previously end up half its real length and drift out of sync with your microphone.</li>
+                    <li>Meetings transcribe after you stop instead of during the call, so recording no longer competes with everything else for CPU.</li>
+                    <li>The installer window is properly branded.</li>
                 </ul>
             ]]></description>
-            <pubDate>Mon, 17 Aug 2026 10:28:37 +0000</pubDate>
-            <sparkle:version>283</sparkle:version>
-            <sparkle:shortVersionString>2.8.3</sparkle:shortVersionString>
+            <pubDate>Fri, 21 Aug 2026 19:16:36 +0000</pubDate>
+            <sparkle:version>284</sparkle:version>
+            <sparkle:shortVersionString>2.8.4</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/arcusis/Zerm/releases/download/v2.8.3/Zerm-2.8.3-macos.zip" length="25297705" type="application/octet-stream" sparkle:edSignature="MwMBLFxoAwkzXjCjf0FeZVlChh9cCWWFagr+cWzbA7xbleTNz03J5zpGXWflqcYavoINme1FXEtthVi1u02FAA=="/>
+            <enclosure url="https://github.com/arcusis/Zerm/releases/download/v2.8.4/Zerm-2.8.4-macos.zip" length="25280486" type="application/octet-stream" sparkle:edSignature="f0GYq09pd2dFk7CVKLjqONGCfWITAFrht/gq9kFHeLnllKtCBo0LWQjERW/lY1AURArfTvtNTbzwtezhh9ABDQ=="/>
         </item>
     </channel>
 </rss>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -291,7 +291,12 @@ if [ "$BRANDED_DMG" = "1" ]; then
     hdiutil attach "$RW_DMG" -noverify -noautoopen
     sleep 2
 
-    osascript <<APPLESCRIPT || echo "    could not style the installer window; shipping it unstyled"
+    # Written to a file and run by path rather than piped through a heredoc. A heredoc here
+    # failed in the 2.8.4 release run with `line 294: tell: command not found` — the body was
+    # executed as shell instead of reaching osascript, and the DMG shipped unstyled while every
+    # other step reported success. A file has no such ambiguity, and can be inspected on failure.
+    STYLE_SCRIPT="$WORK_DIR/style-installer-window.applescript"
+    cat > "$STYLE_SCRIPT" <<APPLESCRIPT
 tell application "Finder"
     tell disk "$VOLUME_NAME"
         open
@@ -306,26 +311,50 @@ tell application "Finder"
         set arrangement of theOptions to not arranged
         set icon size of theOptions to 128
         -- Resolve the background against the disk, not the view options: nesting this inside a
-        -- `tell the icon view options` block makes Finder look for the file there and fail.
+        -- \`tell the icon view options\` block makes Finder look for the file there and fail.
         set background picture of theOptions to file ".background:background.png"
         set position of item "Zerm.app" of theWindow to {170, 218}
         set position of item "Applications" of theWindow to {490, 218}
         delay 1
         update without registering applications
         delay 2
-        close
+        -- Deliberately not closed. Closing the window makes Finder rewrite .DS_Store without
+        -- the background alias, and the styling then vanishes during hdiutil convert. Measured
+        -- over three variants: with `close` the shipped DMG carries 0 background references,
+        -- without it 5. Detaching the volume closes the window anyway.
     end tell
 end tell
 APPLESCRIPT
 
-    sleep 2
-    # The window settings only reach the image once Finder has flushed .DS_Store.
-    if ! strings "/Volumes/$VOLUME_NAME/.DS_Store" 2>/dev/null | grep -q "background.png"; then
-        echo "    warning: installer background was not recorded in .DS_Store"
+    if ! osascript "$STYLE_SCRIPT"; then
+        echo "    could not style the installer window; shipping it unstyled"
     fi
+
+    sleep 3
+    sync
     hdiutil detach "/Volumes/$VOLUME_NAME" -force || true
     hdiutil convert "$RW_DMG" -format UDZO -imagekey zlib-level=9 -o "$DMG_PATH"
     rm -f "$RW_DMG"
+
+    # Verify the DMG that actually ships, not the read-write volume it was built from. An
+    # earlier version checked the staging volume, reported success, and shipped an unstyled DMG
+    # anyway: the reference was present there and gone after convert.
+    VERIFY_MOUNT="$WORK_DIR/verify-mount"
+    rm -rf "$VERIFY_MOUNT"; mkdir -p "$VERIFY_MOUNT"
+    BACKGROUND_REFS=0
+    if hdiutil attach "$DMG_PATH" -nobrowse -noverify -mountpoint "$VERIFY_MOUNT" >/dev/null 2>&1; then
+        BACKGROUND_REFS=$(strings "$VERIFY_MOUNT/.DS_Store" 2>/dev/null | grep -c "background.png" || true)
+        hdiutil detach "$VERIFY_MOUNT" -force >/dev/null 2>&1 || true
+    fi
+    rm -rf "$VERIFY_MOUNT"
+
+    if [ "${BACKGROUND_REFS:-0}" -gt 0 ]; then
+        echo "    installer window styled (verified in the shipped DMG)"
+    else
+        echo "error: the shipped DMG has no installer background."
+        echo "  Set SKIP_DMG_BRANDING=1 to ship it unstyled."
+        [ "${SKIP_DMG_BRANDING:-0}" = "1" ] || exit 1
+    fi
 else
     hdiutil create -volname "$VOLUME_NAME" -srcfolder "$STAGING" -ov -format UDZO "$DMG_PATH"
 fi


### PR DESCRIPTION
Sparkle feed now advertises build 284, so installed 2.8.3 clients can see the update.

The v2.8.4 release is already published with both assets. The Release workflow correctly failed on it — it validates the tag against the appcast committed in the repo, which still said 2.8.3 while the release advertised 2.8.4. This closes that gap.

Also carries the DMG installer-window fix, which had two defects that each reported success while shipping an unstyled image:

- The AppleScript closed the Finder window before detaching. Closing makes Finder rewrite `.DS_Store` without the background alias, and the styling vanishes during `hdiutil convert`. Measured across three variants against the final image: with `close`, 0 background references; without it, 5.
- Verification checked the read-write staging volume rather than the compressed image that ships, so it passed on every run while the artifact was wrong. It now mounts the finished DMG and fails closed on it.

Apple publishes no API for this — [Packaging Mac software for distribution](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution) states that third-party tools or your own configure the window, and requires only that the result be UDZO and Developer ID signed. The shipped image is verified against all three of Apple's stated requirements: `Format: UDZO`, `Authority=Developer ID Application: Arcusis LTD (F9Z784RA6D)`, and `stapler validate` / `spctl` accepted.